### PR TITLE
Add license_file to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ description = Core utilities to serve HDF5 file contents
 long_description = file: README.md
 long_description_content_type = text/markdown
 license = MIT
+license_file = LICENSE
 url = https://github.com/silx-kit/h5core
 project_urls = 
 	Bug Tracker = https://github.com/silx-kit/h5core/-/issues


### PR DESCRIPTION
Work towards #13 

<s>all relevant files will be included in the package: https://packaging.python.org/guides/using-manifest-in/?highlight=manifest#how-files-are-included-in-an-sdist</s> **EDIT: See https://github.com/silx-kit/h5core/pull/18#issuecomment-853701266**