### PR TITLE
Added types-orjson dev dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ dev =
 	pytest-benchmark
 	pytest-cov
 	pytest-tornado
+	types-orjson
 flask =
 	Flask
 	Flask-Compress
@@ -46,6 +47,7 @@ all =
 	pytest-benchmark
 	pytest-cov
 	pytest-tornado
+	types-orjson
 	Flask
 	Flask-Compress
 	Flask-Cors


### PR DESCRIPTION
This should fix CI running `mypy`.

See: https://github.com/silx-kit/h5grove/pull/20/checks?check_run_id=2883418945