### PR TITLE
Allow selection to be a valid slice in data and data_stats

### DIFF
--- a/h5grove/models.py
+++ b/h5grove/models.py
@@ -1,6 +1,8 @@
-from typing import Union
+from typing import Tuple, Union
 import h5py
 
 H5pyEntity = Union[
     h5py.Dataset, h5py.Datatype, h5py.ExternalLink, h5py.Group, h5py.SoftLink
 ]
+
+Selection = Union[str, int, slice, Tuple[Union[slice, int], ...], None]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,35 @@
+from typing import List
 import setuptools
+import sys
+
+
+class Lint(setuptools.Command):
+    user_options: List[str] = []
+    description = "Lint"
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        import subprocess
+
+        lint_steps = [
+            "black --check h5grove/ example/ test/",
+            "flake8",
+            "mypy h5grove/ example/ test/",
+        ]
+
+        for step in lint_steps:
+            cmd = step.split()[0]
+            print(f"Running {cmd}...")
+            errno = subprocess.call([sys.executable, "-m", *step.split()])
+            if errno != 0:
+                raise SystemExit(errno)
+            print(f"{cmd} check passed !")
+
 
 if __name__ == "__main__":
-    setuptools.setup()
+    setuptools.setup(cmdclass={"lint": Lint})


### PR DESCRIPTION
Previously, `selection` had to be a string which hampers reusability if the caller of `.data` already has a valid slice (`int`, `slice` or a tuple of these).

Also add a setup.py command to lint for local dev