### PR TITLE
Using numpy.ravel rather than ndarray.flatten to spare a copy

### DIFF
--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -150,7 +150,7 @@ class DatasetContent(ResolvedEntityContent[h5py.Dataset]):
 
         # Do not flatten scalars nor h5py.Empty
         if flatten and isinstance(result, np.ndarray):
-            return result.flatten()
+            return np.ravel(result)
 
         return result
 


### PR DESCRIPTION
Using [ravel](https://numpy.org/doc/stable/reference/generated/numpy.ravel.html) instead of [flatten](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flatten.html) to spare a memory copy.