### PR TITLE
Add content-length header

### DIFF
--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -1,10 +1,11 @@
 import io
 from numbers import Number
-from typing import Any, Callable, Dict, Generator, NamedTuple, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 import numpy as np
 import orjson
 import h5py
 import tifffile
+
 from .utils import sanitize_array
 
 
@@ -77,11 +78,15 @@ def tiff_encode(data: np.ndarray) -> bytes:
         return buffer.getvalue()
 
 
-class Response(NamedTuple):
-    content: Union[Generator[bytes, None, None], bytes]
-    """ Encoded `content` as a generator of bytes """
+class Response:
+    content: bytes
+    """ Encoded `content` as bytes """
     headers: Dict[str, str]
     """ Associated headers """
+
+    def __init__(self, content: bytes, headers: Dict[str, str]):
+        self.content = content
+        self.headers = {**headers, "Content-Length": str(len(content))}
 
 
 def encode(content, encoding: Optional[str] = "json") -> Response:

--- a/h5grove/flaskutils.py
+++ b/h5grove/flaskutils.py
@@ -21,9 +21,9 @@ __all__ = [
 
 def make_encoded_response(content, format_arg: Optional[str]) -> Response:
     """Prepare flask Response according to format"""
-    encoded_content, headers = encode(content, format_arg)
-    response = Response(encoded_content)
-    response.headers.update(headers)
+    h5grove_response = encode(content, format_arg)
+    response = Response(h5grove_response.content)
+    response.headers.update(h5grove_response.headers)
     return response
 
 

--- a/h5grove/tornadoutils.py
+++ b/h5grove/tornadoutils.py
@@ -1,6 +1,6 @@
 """Helpers for usage with `Tornado <https://www.tornadoweb.org>`_"""
 import os
-from typing import Any, Generator, Optional
+from typing import Any, Optional
 import h5py
 from tornado.web import RequestHandler, MissingArgumentError, HTTPError
 
@@ -44,16 +44,12 @@ class BaseHandler(RequestHandler):
             except NotFoundError as e:
                 raise HTTPError(status_code=404, reason=str(e))
 
-        chunks, headers = encode(content, format_arg)
+        response = encode(content, format_arg)
 
-        for key, value in headers.items():
+        for key, value in response.headers.items():
             self.set_header(key, value)
 
-        if isinstance(chunks, Generator):
-            for chunk in chunks:
-                self.write(chunk)
-        else:
-            self.write(chunks)
+        self.write(response.content)
         self.finish()
 
     def get_content(self, h5file: h5py.File, path: Optional[str]):


### PR DESCRIPTION
The `Content-Length` header is needed to display download progress: https://github.com/silx-kit/h5web/pull/908.

Flask already adds it automatically in the `flask.Response` object so I add it manually for tornado.

We could argue that the header could be set when creating the `h5grove.Response` but as Flask adds it already, perhaps it is easier that the implementing back-end has the responsibility of adding it?

What do you think @t20100 @axelboc ?