### PR TITLE
Convert float128 in float when serializing to JSON

### DIFF
--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -19,10 +19,13 @@ def bin_encode(array: Sequence[Number]) -> bytes:
     return sanitized_array.tobytes()
 
 
-def orjson_default(o: Any) -> Union[list, str, None]:
+def orjson_default(o: Any) -> Union[list, float, str, None]:
     """Converts Python objects to JSON-serializable objects.
 
     :raises TypeError: if the object is not supported."""
+    if isinstance(o, np.float128):
+        # float128 is not converted to native float by NumPy so we need to force it even if it means loosing precision
+        return float(o)
     if isinstance(o, (np.generic, np.ndarray)):
         return o.tolist()
     if isinstance(o, complex):


### PR DESCRIPTION
To solve recursion loops when looking at `float128`: https://github.com/silx-kit/jupyterlab-h5web/issues/84