### PR TITLE
Fix handling of np.float128

### DIFF
--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -23,7 +23,7 @@ def orjson_default(o: Any) -> Union[list, float, str, None]:
     """Converts Python objects to JSON-serializable objects.
 
     :raises TypeError: if the object is not supported."""
-    if isinstance(o, np.number) and o.dtype.kind == 'f' and o.itemsize > 8:
+    if isinstance(o, np.number) and o.dtype.kind == "f" and o.itemsize > 8:
         # Force conversion of float >64bits to native float even if it means losing precision
         return float(o)
     if isinstance(o, (np.generic, np.ndarray)):

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -8,8 +8,6 @@ import tifffile
 
 from .utils import sanitize_array
 
-SUPPORTS_FLOAT128 = hasattr(np, "float128")
-
 
 def bin_encode(array: Sequence[Number]) -> bytes:
     """Sanitize an array and convert it to bytes.
@@ -25,8 +23,8 @@ def orjson_default(o: Any) -> Union[list, float, str, None]:
     """Converts Python objects to JSON-serializable objects.
 
     :raises TypeError: if the object is not supported."""
-    if SUPPORTS_FLOAT128 and isinstance(o, np.float128):
-        # float128 is not converted to native float by NumPy so we need to force it even if it means losing precision
+    if isinstance(o, np.number) and o.dtype.kind == 'f' and o.itemsize > 8:
+        # Force conversion of float >64bits to native float even if it means losing precision
         return float(o)
     if isinstance(o, (np.generic, np.ndarray)):
         return o.tolist()

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -8,6 +8,8 @@ import tifffile
 
 from .utils import sanitize_array
 
+SUPPORTS_FLOAT128 = hasattr(np, "float128")
+
 
 def bin_encode(array: Sequence[Number]) -> bytes:
     """Sanitize an array and convert it to bytes.
@@ -23,7 +25,7 @@ def orjson_default(o: Any) -> Union[list, float, str, None]:
     """Converts Python objects to JSON-serializable objects.
 
     :raises TypeError: if the object is not supported."""
-    if hasattr(np, 'float128') and isinstance(o, np.float128):
+    if SUPPORTS_FLOAT128 and isinstance(o, np.float128):
         # float128 is not converted to native float by NumPy so we need to force it even if it means losing precision
         return float(o)
     if isinstance(o, (np.generic, np.ndarray)):

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -23,8 +23,8 @@ def orjson_default(o: Any) -> Union[list, float, str, None]:
     """Converts Python objects to JSON-serializable objects.
 
     :raises TypeError: if the object is not supported."""
-    if isinstance(o, np.float128):
-        # float128 is not converted to native float by NumPy so we need to force it even if it means loosing precision
+    if hasattr(np, 'float128') and isinstance(o, np.float128):
+        # float128 is not converted to native float by NumPy so we need to force it even if it means losing precision
         return float(o)
     if isinstance(o, (np.generic, np.ndarray)):
         return o.tolist()


### PR DESCRIPTION
Some distributions of numpy don't work with float128 (see https://stackoverflow.com/questions/29820829/cannot-use-128bit-float-in-python-on-64bit-architecture)
I've added a simple check to prevent errors