### PR TITLE
Added `dtype` argument to `encode` and `/data/` endpoint

### DIFF
--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -166,7 +166,7 @@ components:
   parameters:
     dtype:
       name: dtype
-      description: Data type of the response. Ignored if format is 'json'. Defaults to dataset dtype (sanitized for 'bin' format).
+      description: Data type of the response. Defaults to dataset dtype (sanitized for 'bin' format).
       in: query
       schema:
         type: string

--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -166,11 +166,12 @@ components:
   parameters:
     dtype:
       name: dtype
-      description: Data type of the response. Defaults to dataset dtype (sanitized for 'bin' format).
+      description: Data type conversion. Only for arrays and scalars. Defaults to "origin".
       in: query
       schema:
+        enum: ['origin', 'safe']
         type: string
-      example: 'float32', '<f4'
+      example: 'safe'
     file:
       name: file
       description: Location of the HDF5 file.

--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -56,6 +56,7 @@ paths:
       summary: Get data of a dataset
       description: Retrieves data contained in a dataset or a slice of dataset
       parameters:
+        - $ref: '#/components/parameters/dtype'
         - $ref: '#/components/parameters/file'
         - $ref: '#/components/parameters/format'
         - $ref: '#/components/parameters/flatten'
@@ -163,6 +164,13 @@ paths:
 
 components:
   parameters:
+    dtype:
+      name: dtype
+      description: Data type of the response. Ignored if format is 'json'. Defaults to dataset dtype (sanitized for 'bin' format).
+      in: query
+      schema:
+        type: string
+      example: 'float32', '<f4'
     file:
       name: file
       description: Location of the HDF5 file.

--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -10,6 +10,7 @@ except ImportError:
 from .models import LinkResolution, Selection
 from .utils import (
     attr_metadata,
+    convert,
     get_array_stats,
     get_filters,
     get_entity_from_file,
@@ -147,9 +148,21 @@ class DatasetContent(ResolvedEntityContent[h5py.Dataset]):
             *super().metadata().items(),
         )
 
-    def data(self, selection: Selection = None, flatten: bool = False):
-        """Dataset data. Supports slicing through selection."""
-        result = get_dataset_slice(self._h5py_entity, selection)
+    def data(
+        self,
+        selection: Selection = None,
+        flatten: bool = False,
+        dtype: Optional[str] = "origin",
+    ):
+        """Dataset data.
+
+        :param selection: Slicing information
+        :param flatten: True to flatten the returned array
+        :param dtype: Data type conversion query parameter
+          - `origin` (default): No conversion
+          - `safe`: Convert to a type supported by JS typedarray (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+        """
+        result = convert(get_dataset_slice(self._h5py_entity, selection), dtype)
 
         # Do not flatten scalars nor h5py.Empty
         if flatten and isinstance(result, np.ndarray):

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -5,7 +5,7 @@ import orjson
 import h5py
 import tifffile
 
-from .utils import is_numeric_content, sanitize_array
+from .utils import is_numeric_array, sanitize_array
 
 
 def bin_encode(array: np.ndarray) -> bytes:
@@ -113,9 +113,11 @@ def encode(
     if dtype in ("origin", None):
         cast_content = content
     elif dtype == "safe":
-        if not is_numeric_content(content):
+        cast_content = np.array(content, copy=False)
+        if not is_numeric_array(cast_content):
             raise ValueError(f"Unsupported dtype {dtype} for non-numeric content")
-        cast_content = sanitize_array(content, copy=False)
+        cast_content = sanitize_array(cast_content, copy=False)
+
     else:
         raise ValueError(f"Unsupported dtype {dtype}")
 
@@ -125,10 +127,9 @@ def encode(
             headers={"Content-Type": "application/json"},
         )
 
-    if not is_numeric_content(cast_content):
-        raise ValueError(f"Unsupported encoding {encoding} for non-numeric content")
-
     content_array = np.array(cast_content, copy=False)
+    if not is_numeric_array(content_array):
+        raise ValueError(f"Unsupported encoding {encoding} for non-numeric content")
 
     if encoding == "bin":
         return Response(

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -1,6 +1,5 @@
 import io
-from numbers import Number
-from typing import Any, Callable, Dict, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Optional, Union
 import numpy as np
 import orjson
 import h5py
@@ -9,14 +8,15 @@ import tifffile
 from .utils import sanitize_array
 
 
-def bin_encode(array: Sequence[Number]) -> bytes:
-    """Sanitize an array and convert it to bytes.
+def bin_encode(array: np.ndarray, sanitize: bool = True) -> bytes:
+    """Convert array to bytes.
 
     :param array: Data to convert
+    :param sanitize: Whether to use a sanitized dtype or not
     """
-    sanitized_array = sanitize_array(array)
+    sent_array = sanitize_array(array) if sanitize else array
 
-    return sanitized_array.tobytes()
+    return sent_array.tobytes()
 
 
 def orjson_default(o: Any) -> Union[list, float, str, None]:

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -5,7 +5,7 @@ import orjson
 import h5py
 import tifffile
 
-from .utils import sanitize_array
+from .utils import is_numeric_content, sanitize_array
 
 
 def bin_encode(array: np.ndarray) -> bytes:
@@ -113,6 +113,8 @@ def encode(
     if dtype in ("origin", None):
         cast_content = content
     elif dtype == "safe":
+        if not is_numeric_content(content):
+            raise ValueError(f"Unsupported dtype {dtype} for non-numeric content")
         cast_content = sanitize_array(content, copy=False)
     else:
         raise ValueError(f"Unsupported dtype {dtype}")
@@ -122,6 +124,9 @@ def encode(
             orjson_encode(cast_content),
             headers={"Content-Type": "application/json"},
         )
+
+    if not is_numeric_content(cast_content):
+        raise ValueError(f"Unsupported encoding {encoding} for non-numeric content")
 
     content_array = np.array(cast_content, copy=False)
 

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -107,17 +107,22 @@ def encode(
         - `npy`: nD arrays in downloadable npy files
         - `tiff`: 2D arrays in downloadable TIFF files
     :param dtype: Data type to convert content to before encoding
-        Only supported for nD array/scalars, ignored if `format='json'`.
+        Only supported for nD array/scalars.
     :returns: A Response object containing content and headers
     :raises ValueError: If encoding is not among the ones above.
     """
+    if dtype is not None:
+        typed_content = np.array(content, dtype=dtype, order="C", copy=False)
+    else:
+        typed_content = content
+
     if encoding in ("json", None):
         return Response(
-            orjson_encode(content),
+            orjson_encode(typed_content),
             headers={"Content-Type": "application/json"},
         )
 
-    array_content = np.array(content, dtype=dtype, order="C", copy=False)
+    array_content = np.array(typed_content, order="C", copy=False)
 
     if encoding == "bin":
         return Response(

--- a/h5grove/flaskutils.py
+++ b/h5grove/flaskutils.py
@@ -21,9 +21,11 @@ __all__ = [
 ]
 
 
-def make_encoded_response(content, format_arg: Optional[str]) -> Response:
+def make_encoded_response(
+    content, format_arg: Optional[str], dtype_arg: Optional[str] = None
+) -> Response:
     """Prepare flask Response according to format"""
-    h5grove_response = encode(content, format_arg)
+    h5grove_response = encode(content, format_arg, dtype_arg)
     response = Response(h5grove_response.content)
     response.headers.update(h5grove_response.headers)
     return response
@@ -74,12 +76,15 @@ def data_route():
     path = request.args.get("path")
     selection = request.args.get("selection")
     format_arg = request.args.get("format")
+    dtype_arg = request.args.get("dtype", None)
     flatten = parse_bool_arg(request.args.get("flatten"), fallback=False)
 
     with h5py.File(filename, mode="r") as h5file:
         content = get_content(h5file, path)
         assert isinstance(content, DatasetContent)
-        return make_encoded_response(content.data(selection, flatten), format_arg)
+        return make_encoded_response(
+            content.data(selection, flatten), format_arg, dtype_arg
+        )
 
 
 def meta_route():

--- a/h5grove/tornadoutils.py
+++ b/h5grove/tornadoutils.py
@@ -34,6 +34,7 @@ class BaseHandler(RequestHandler):
 
         path = self.get_query_argument("path", None, strip=False)
         format_arg = self.get_query_argument("format", None)
+        dtype_arg = self.get_query_argument("dtype", None)
 
         full_file_path = os.path.join(self.base_dir, file_path)
         if not os.path.isfile(full_file_path):
@@ -45,7 +46,7 @@ class BaseHandler(RequestHandler):
             except NotFoundError as e:
                 raise HTTPError(status_code=404, reason=str(e))
 
-        response = encode(content, format_arg)
+        response = encode(content, format_arg, dtype_arg)
 
         for key, value in response.headers.items():
             self.set_header(key, value)

--- a/h5grove/tornadoutils.py
+++ b/h5grove/tornadoutils.py
@@ -5,7 +5,7 @@ import h5py
 from tornado.web import RequestHandler, MissingArgumentError, HTTPError
 
 from .content import DatasetContent, ResolvedEntityContent, create_content
-from .encoders import encode
+from .encoders import encode, Response
 from .models import LinkResolution
 from .utils import NotFoundError, parse_bool_arg, parse_link_resolution_arg
 
@@ -33,8 +33,6 @@ class BaseHandler(RequestHandler):
             raise MissingArgumentError("file")
 
         path = self.get_query_argument("path", None, strip=False)
-        format_arg = self.get_query_argument("format", None)
-        dtype_arg = self.get_query_argument("dtype", None)
 
         full_file_path = os.path.join(self.base_dir, file_path)
         if not os.path.isfile(full_file_path):
@@ -42,11 +40,9 @@ class BaseHandler(RequestHandler):
 
         with h5py.File(full_file_path, "r") as h5file:
             try:
-                content = self.get_content(h5file, path)
+                response = self.get_response(h5file, path)
             except NotFoundError as e:
                 raise HTTPError(status_code=404, reason=str(e))
-
-        response = encode(content, format_arg, dtype_arg)
 
         for key, value in response.headers.items():
             self.set_header(key, value)
@@ -54,7 +50,7 @@ class BaseHandler(RequestHandler):
         self.write(response.content)
         self.finish()
 
-    def get_content(self, h5file: h5py.File, path: Optional[str]):
+    def get_response(self, h5file: h5py.File, path: Optional[str]) -> Response:
         raise NotImplementedError
 
     def prepare(self):
@@ -69,19 +65,21 @@ class BaseHandler(RequestHandler):
 class AttributeHandler(BaseHandler):
     """/attr/ endpoint handler"""
 
-    def get_content(self, h5file: h5py.File, path: Optional[str]):
+    def get_response(self, h5file: h5py.File, path: Optional[str]) -> Response:
         content = create_content(h5file, path)
         assert isinstance(content, ResolvedEntityContent)
 
         attr_keys = self.get_query_arguments("attr_keys", strip=False)
         # get_query_arguments returns an empty list if `attr_keys` is not present
-        return content.attributes(attr_keys if len(attr_keys) > 0 else None)
+        return encode(content.attributes(attr_keys if len(attr_keys) > 0 else None))
 
 
 class DataHandler(BaseHandler):
     """/data/ endpoint handler"""
 
-    def get_content(self, h5file: h5py.File, path: Optional[str]):
+    def get_response(self, h5file: h5py.File, path: Optional[str]) -> Response:
+        dtype = self.get_query_argument("dtype", None)
+        format_arg = self.get_query_argument("format", None)
         selection = self.get_query_argument("selection", None)
         flatten = parse_bool_arg(
             self.get_query_argument("flatten", None), fallback=False
@@ -89,30 +87,31 @@ class DataHandler(BaseHandler):
 
         content = create_content(h5file, path)
         assert isinstance(content, DatasetContent)
-        return content.data(selection, flatten)
+        data = content.data(selection, flatten, dtype)
+        return encode(data, format_arg)
 
 
 class MetadataHandler(BaseHandler):
     """/meta/ endpoint handler"""
 
-    def get_content(self, h5file: h5py.File, path: Optional[str]):
+    def get_response(self, h5file: h5py.File, path: Optional[str]) -> Response:
         resolve_links = parse_link_resolution_arg(
             self.get_query_argument("resolve_links", None),
             fallback=LinkResolution.ONLY_VALID,
         )
         content = create_content(h5file, path, resolve_links)
-        return content.metadata()
+        return encode(content.metadata())
 
 
 class StatisticsHandler(BaseHandler):
     """/stats/ endpoint handler"""
 
-    def get_content(self, h5file: h5py.File, path: Optional[str]):
+    def get_response(self, h5file: h5py.File, path: Optional[str]) -> Response:
         selection = self.get_query_argument("selection", None)
 
         content = create_content(h5file, path)
         assert isinstance(content, DatasetContent)
-        return content.data_stats(selection)
+        return encode(content.data_stats(selection))
 
 
 # TODO: Setting the return type raises mypy errors

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -136,9 +136,8 @@ def sanitize_array(array: Sequence[Number], copy: bool = True) -> np.ndarray:
     return np.array(ndarray, copy=copy, order="C", dtype=_sanitize_dtype(ndarray.dtype))
 
 
-def is_numeric_content(content: Any) -> bool:
-    """Checks if content is a number or an array of numbers"""
-    return isinstance(content, (np.ndarray, Number))
+def is_numeric_array(array: np.ndarray) -> bool:
+    return np.issubdtype(array.dtype, np.number) or np.issubdtype(array.dtype, np.bool_)
 
 
 def get_array_stats(data: np.ndarray) -> Dict[str, Union[float, int, None]]:

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -1,8 +1,7 @@
 import h5py
-from numbers import Number
 from os.path import basename
 import numpy as np
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .models import H5pyEntity, LinkResolution, Selection
 
@@ -125,19 +124,29 @@ def _sanitize_dtype(dtype: np.dtype) -> np.dtype:
     return result
 
 
-def sanitize_array(array: Sequence[Number], copy: bool = True) -> np.ndarray:
-    """Ensure array can be converted to a JS TypedArray (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
+def convert(
+    data: Union[np.ndarray, np.number, np.bool_], dtype: Optional[str] = "origin"
+) -> Union[np.ndarray, np.number, np.bool_]:
+    """Convert array or numpy scalar to given dtype query param
 
-    :param array: Array to sanitize
-    :param copy: Set to False to avoid copy if possible
-    :raises ValueError: For unsupported array dtype
+    :param data: nD array or scalar to convert
+    :param dtype: Data type conversion query parameter
+        - `origin` (default): No conversion
+        - `safe`: Convert to a type supported by JS typedarray (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
     """
-    ndarray = np.array(array, copy=False)
-    return np.array(ndarray, copy=copy, order="C", dtype=_sanitize_dtype(ndarray.dtype))
+    if dtype in ("origin", None):
+        return data
+
+    if dtype == "safe":
+        if not is_numeric_data(data):
+            raise ValueError(f"Unsupported dtype {dtype} for non-numeric content")
+        return data.astype(_sanitize_dtype(data.dtype), order="C", copy=False)
+
+    raise ValueError(f"Unsupported dtype {dtype}")
 
 
-def is_numeric_array(array: np.ndarray) -> bool:
-    return np.issubdtype(array.dtype, np.number) or np.issubdtype(array.dtype, np.bool_)
+def is_numeric_data(data: np.ndarray) -> bool:
+    return np.issubdtype(data.dtype, np.number) or np.issubdtype(data.dtype, np.bool_)
 
 
 def get_array_stats(data: np.ndarray) -> Dict[str, Union[float, int, None]]:

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -145,7 +145,7 @@ def convert(
     raise ValueError(f"Unsupported dtype {dtype}")
 
 
-def is_numeric_data(data: np.ndarray) -> bool:
+def is_numeric_data(data: Union[np.ndarray, np.number, np.bool_]) -> bool:
     return np.issubdtype(data.dtype, np.number) or np.issubdtype(data.dtype, np.bool_)
 
 

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -1,7 +1,7 @@
 import h5py
 from os.path import basename
 import numpy as np
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
 from .models import H5pyEntity, LinkResolution, Selection
 
@@ -124,9 +124,10 @@ def _sanitize_dtype(dtype: np.dtype) -> np.dtype:
     return result
 
 
-def convert(
-    data: Union[np.ndarray, np.number, np.bool_], dtype: Optional[str] = "origin"
-) -> Union[np.ndarray, np.number, np.bool_]:
+T = TypeVar("T", np.ndarray, np.number, np.bool_)
+
+
+def convert(data: T, dtype: Optional[str] = "origin") -> T:
     """Convert array or numpy scalar to given dtype query param
 
     :param data: nD array or scalar to convert

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -126,9 +126,9 @@ def _sanitize_dtype(dtype: np.dtype) -> np.dtype:
 
 
 def sanitize_array(array: Sequence[Number], copy: bool = True) -> np.ndarray:
-    """Ensure array save as .npy can be read back by js-numpy-parser.
+    """Ensure array can be converted to a typedarray.
 
-    See https://github.com/ludwigschubert/js-numpy-parser
+    This is compatible with js-numpy-parser, see https://github.com/ludwigschubert/js-numpy-parser
 
     :param array: Array to sanitize
     :param copy: Set to False to avoid copy if possible

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -126,9 +126,8 @@ def _sanitize_dtype(dtype: np.dtype) -> np.dtype:
 
 
 def sanitize_array(array: Sequence[Number], copy: bool = True) -> np.ndarray:
-    """Ensure array can be converted to a typedarray.
+    """Ensure array can be converted to a JS TypedArray (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
 
-    This is compatible with js-numpy-parser, see https://github.com/ludwigschubert/js-numpy-parser
 
     :param array: Array to sanitize
     :param copy: Set to False to avoid copy if possible

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -128,13 +128,17 @@ def _sanitize_dtype(dtype: np.dtype) -> np.dtype:
 def sanitize_array(array: Sequence[Number], copy: bool = True) -> np.ndarray:
     """Ensure array can be converted to a JS TypedArray (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/TypedArray).
 
-
     :param array: Array to sanitize
     :param copy: Set to False to avoid copy if possible
     :raises ValueError: For unsupported array dtype
     """
     ndarray = np.array(array, copy=False)
     return np.array(ndarray, copy=copy, order="C", dtype=_sanitize_dtype(ndarray.dtype))
+
+
+def is_numeric_content(content: Any) -> bool:
+    """Checks if content is a number or an array of numbers"""
+    return isinstance(content, (np.ndarray, Number))
 
 
 def get_array_stats(data: np.ndarray) -> Dict[str, Union[float, int, None]]:

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -34,9 +34,8 @@ def decode_array_response(
     """Decode data array response content according to given information"""
     content_type = [h[1] for h in response.headers if h[0] == "Content-Type"][0]
 
-    if format == "npy":
-        assert content_type == "application/octet-stream"
-        return np.load(io.BytesIO(response.content))
+    if format in ("json", "npy"):
+        return np.array(decode_response(response, format), copy=False)
     if format == "bin":
         assert content_type == "application/octet-stream"
         return np.frombuffer(response.content, dtype=dtype).reshape(shape)
@@ -100,7 +99,7 @@ class BaseTestEndpoints:
 
         assert np.array_equal(retrieved_data, data.flatten() if flatten else data)
 
-    @pytest.mark.parametrize("format_arg", ("npy", "bin"))
+    @pytest.mark.parametrize("format_arg", ("json", "npy", "bin"))
     @pytest.mark.parametrize("dtype", ("int", "<f2"))
     def test_data_on_array_with_dtype(self, server, format_arg, dtype):
         """Test /data/ endpoint on array dataset with dtype"""

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -32,7 +32,7 @@ def decode_array_response(
     shape: Tuple[int],
 ) -> np.ndarray:
     """Decode data array response content according to given information"""
-    content_type = [h[1] for h in response.headers if h[0] == "Content-Type"][0]
+    content_type = {h[0]: h[1] for h in response.headers}["Content-Type"]
 
     if format == "bin":
         assert content_type == "application/octet-stream"
@@ -105,7 +105,8 @@ class BaseTestEndpoints:
         # Test condition
         tested_h5entity_path = "/entry/image"
         data = np.random.random((128, 128)).astype(">f2")
-        ref_dtype = data.dtype if dtype_arg == "origin" else "<f4"
+        # No Float16Array in JS => converted to float32
+        ref_dtype = "<f4" if dtype_arg == "safe" else ">f2"
 
         filename = "test.h5"
         with h5py.File(server.served_directory / filename, mode="w") as h5file:


### PR DESCRIPTION
This PR adds a `dtype` query param to the `/data/` endpoint and the corresponding `dtype` argument to the `encode` function.

As it is now, it is backward compatible when `dtype` is not provided, but we might want to change that:
Only the `bin` format sanitizes the array while the other formats do not. Only considering `h5grove`, it sounds a random choice...
This "sanitize" behavior can be provided through e.g., `dtype=safe` (or 'typedarray') and by default the data is returned as is for all `format`s.

This provides a generic solution to #61.
 
closes #61