### PR TITLE
Add support of pre-releases to bump2version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,6 +4,17 @@ tag = True
 commit = True
 message = Bump to v{new_version}
 tag_message = {now:%Y/%m/%d}
+parse = (?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)((?P<prerelease>.*)(?P<pre>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{prerelease}{pre}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:prerelease]
+optional_value = final
+first_value = final
+values = 
+	b
+	final
 
 [bumpversion:file:h5grove/__init__.py]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,8 +62,10 @@ The new tag will trigger the CI (`release.yml`) that will build and release the 
 
 Release notes can then be written in the [Releases page](https://github.com/silx-kit/h5grove/releases).
 
+### Pre-releases
+
 The following commands can be used to handle the pre-release cycle:
-- To tag the first pre-release, run `bump2version --new-release <X.Y.Zb0> [patch|minor|major]`
+- To tag the first pre-release, run `bump2version --new-version <X.Y.Zb0> [patch|minor|major]` where `X.Y.Z` is the version number of the next release
 - To bump the pre-release number, run `bump2version pre`
 - To bump to the release, run `bump2version prerelease`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ The new tag will trigger the CI (`release.yml`) that will build and release the 
 
 Release notes can then be written in the [Releases page](https://github.com/silx-kit/h5grove/releases).
 
+The following commands can be used to handle the pre-release cycle:
+- To tag the first pre-release, run `bump2version --new-release <X.Y.Zb0> [patch|minor|major]`
+- To bump the pre-release number, run `bump2version pre`
+- To bump to the release, run `bump2version prerelease`
+
 ### Documentation
 
 The documentation is generated using [Sphinx](https://www.sphinx-doc.org/en/master/index.html) by parsing Markdown files with [myst-parser](https://myst-parser.readthedocs.io/en/latest/index.html).


### PR DESCRIPTION
This allows to tag beta versions and to go back to releases with a single `--new-version` to explicitly pass