### PR TITLE
Added a fastapi router

### DIFF
--- a/example/fastapi_app.py
+++ b/example/fastapi_app.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# coding: utf-8
+"""FastAPI-based server sample code"""
+import argparse
+import os
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+# Disable libhdf5 file locking since h5grove is only reading files
+# This needs to be done before any import of h5py, so before h5grove import
+os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
+from h5grove.fastapi_router import router, settings  # noqa
+
+
+def parser_fn():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-p", "--port", type=int, default=8888, help="Port the server is listening on"
+    )
+    parser.add_argument(
+        "--ip", default="localhost", help="IP the server is listening on"
+    )
+    parser.add_argument(
+        "--basedir",
+        default=".",
+        help="Base directory from which to retrieve HDF5 files",
+    )
+    return parser
+
+
+app = FastAPI()
+app.include_router(router)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins="*",
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+if __name__ == "__main__":
+    parser = parser_fn()
+    options = parser.parse_args()
+
+    settings.base_dir = options.basedir
+
+    uvicorn.run("fastapi_app:app", host=options.ip, port=options.port, log_level="info")

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -15,43 +15,41 @@ async def add_base_path(file):
     return f"{base_path}/{file}" if base_path else file
 
 
-async def get_h5file(file: str = Depends(add_base_path)):
-    return h5py.File(file, mode="r")
-
-
 @router.get("/attr/")
 async def get_attr(
-    file: h5py.File = Depends(get_h5file),
+    file: str = Depends(add_base_path),
     path: str = "/",
     attr_keys: Optional[List[str]] = Query(default=None),
 ):
-    content = create_content(file, path)
-    assert isinstance(content, ResolvedEntityContent)
-    return content.attributes(attr_keys)
+    with h5py.File(file, "r") as h5file:
+        content = create_content(h5file, path)
+        assert isinstance(content, ResolvedEntityContent)
+        return content.attributes(attr_keys)
 
 
 @router.get("/data/")
 async def get_data(
-    file: h5py.File = Depends(get_h5file),
+    file: str = Depends(add_base_path),
     path: str = "/",
     dtype: str = "origin",
     format: str = "json",
     flatten: bool = False,
     selection=None,
 ):
-    content = create_content(file, path)
-    assert isinstance(content, DatasetContent)
-    data = content.data(selection, flatten, dtype)
-    return (
-        data
-        if format != "bin"
-        else Response(data.tobytes(), media_type="application/octet-stream")
-    )
+    with h5py.File(file, "r") as h5file:
+        content = create_content(h5file, path)
+        assert isinstance(content, DatasetContent)
+        data = content.data(selection, flatten, dtype)
+        return (
+            data
+            if format != "bin"
+            else Response(data.tobytes(), media_type="application/octet-stream")
+        )
 
 
 @router.get("/meta/")
 async def get_meta(
-    file: h5py.File = Depends(get_h5file),
+    file: str = Depends(add_base_path),
     path: str = "/",
     resolve_links: str = "only_valid",
 ):
@@ -59,14 +57,16 @@ async def get_meta(
         resolve_links,
         fallback=LinkResolution.ONLY_VALID,
     )
-    con = create_content(file, path)
-    return con.metadata()
+    with h5py.File(file, "r") as h5file:
+        con = create_content(h5file, path)
+        return con.metadata()
 
 
 @router.get("/stats/")
 async def get_stats(
-    file: h5py.File = Depends(get_h5file), path: str = "/", selection=None
+    file: str = Depends(add_base_path), path: str = "/", selection=None
 ):
-    content = create_content(file, path)
-    assert isinstance(content, DatasetContent)
-    return content.data_stats(selection)
+    with h5py.File(file, "r") as h5file:
+        content = create_content(h5file, path)
+        assert isinstance(content, DatasetContent)
+        return content.data_stats(selection)

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, Depends, Response
+import h5py
+from typing import List
+
+from .content import DatasetContent, ResolvedEntityContent, create_content
+from .models import LinkResolution
+from .utils import parse_link_resolution_arg
+
+router = APIRouter()
+
+base_path = None
+
+
+async def add_base_path(file):
+    return f"{base_path}/{file}" if base_path else file
+
+
+async def get_h5file(file: str = Depends(add_base_path)):
+    return h5py.File(file, mode="r")
+
+
+@router.get("/attr/")
+async def get_attr(
+    file: h5py.File = Depends(get_h5file), path: str = "/", attr_keys: List[str] = []
+):
+    content = create_content(file, path)
+    assert isinstance(content, ResolvedEntityContent)
+    return content.attributes(attr_keys)
+
+
+@router.get("/data/")
+async def get_data(
+    file: h5py.File = Depends(get_h5file),
+    path: str = "/",
+    dtype: str = "origin",
+    format: str = "json",
+    flatten: bool = False,
+    selection=None,
+):
+    content = create_content(file, path)
+    assert isinstance(content, DatasetContent)
+    data = content.data(selection, flatten, dtype)
+    return (
+        data
+        if format != "bin"
+        else Response(data.tobytes(), media_type="application/octet-stream")
+    )
+
+
+@router.get("/meta/")
+async def get_meta(
+    file: h5py.File = Depends(get_h5file),
+    path: str = "/",
+    resolve_links: str = "only_valid",
+):
+    resolve_links = parse_link_resolution_arg(
+        resolve_links,
+        fallback=LinkResolution.ONLY_VALID,
+    )
+    con = create_content(file, path)
+    return con.metadata()
+
+
+@router.get("/stats/")
+async def get_stats(
+    file: h5py.File = Depends(get_h5file), path: str = "/", selection=None
+):
+    content = create_content(file, path)
+    assert isinstance(content, DatasetContent)
+    return content.data_stats(selection)

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, Depends, Response, Query, HTTPException
+from pydantic import BaseSettings
 import h5py
 import os
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from .content import DatasetContent, ResolvedEntityContent, create_content
 from .models import LinkResolution
@@ -9,7 +10,12 @@ from .utils import NotFoundError, parse_link_resolution_arg
 
 router = APIRouter()
 
-base_path = None
+
+class Settings(BaseSettings):
+    base_dir: Union[str, None] = None
+
+
+settings = Settings()
 
 
 def get_content(
@@ -25,7 +31,7 @@ def get_content(
 
 
 async def add_base_path(file):
-    filepath = f"{base_path}/{file}" if base_path else file
+    filepath = f"{settings.base_dir}/{file}" if settings.base_dir else file
     if not os.path.isfile(filepath):
         raise HTTPException(status_code=404, detail="File not found!")
     return filepath

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -1,18 +1,34 @@
-from fastapi import APIRouter, Depends, Response, Query
+from fastapi import APIRouter, Depends, Response, Query, HTTPException
 import h5py
+import os
 from typing import List, Optional
 
 from .content import DatasetContent, ResolvedEntityContent, create_content
 from .models import LinkResolution
-from .utils import parse_link_resolution_arg
+from .utils import NotFoundError, parse_link_resolution_arg
 
 router = APIRouter()
 
 base_path = None
 
 
+def get_content(
+    h5file: h5py.File,
+    path: Optional[str],
+    resolve_links: LinkResolution = LinkResolution.ONLY_VALID,
+):
+    """Gets contents if path is in file. Raises 404 otherwise"""
+    try:
+        return create_content(h5file, path, resolve_links)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
 async def add_base_path(file):
-    return f"{base_path}/{file}" if base_path else file
+    filepath = f"{base_path}/{file}" if base_path else file
+    if not os.path.isfile(filepath):
+        raise HTTPException(status_code=404, detail="File not found!")
+    return filepath
 
 
 @router.get("/attr/")
@@ -22,7 +38,7 @@ async def get_attr(
     attr_keys: Optional[List[str]] = Query(default=None),
 ):
     with h5py.File(file, "r") as h5file:
-        content = create_content(h5file, path)
+        content = get_content(h5file, path)
         assert isinstance(content, ResolvedEntityContent)
         return content.attributes(attr_keys)
 
@@ -37,7 +53,7 @@ async def get_data(
     selection=None,
 ):
     with h5py.File(file, "r") as h5file:
-        content = create_content(h5file, path)
+        content = get_content(h5file, path)
         assert isinstance(content, DatasetContent)
         data = content.data(selection, flatten, dtype)
         return (
@@ -58,7 +74,7 @@ async def get_meta(
         fallback=LinkResolution.ONLY_VALID,
     )
     with h5py.File(file, "r") as h5file:
-        content = create_content(h5file, path, resolve_links=resolve_links)
+        content = get_content(h5file, path, resolve_links=resolve_links)
         return content.metadata()
 
 
@@ -67,6 +83,6 @@ async def get_stats(
     file: str = Depends(add_base_path), path: str = "/", selection=None
 ):
     with h5py.File(file, "r") as h5file:
-        content = create_content(h5file, path)
+        content = get_content(h5file, path)
         assert isinstance(content, DatasetContent)
         return content.data_stats(selection)

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Response, Query
 import h5py
-from typing import List
+from typing import List, Optional
 
 from .content import DatasetContent, ResolvedEntityContent, create_content
 from .models import LinkResolution
@@ -21,7 +21,9 @@ async def get_h5file(file: str = Depends(add_base_path)):
 
 @router.get("/attr/")
 async def get_attr(
-    file: h5py.File = Depends(get_h5file), path: str = "/", attr_keys: List[str] = []
+    file: h5py.File = Depends(get_h5file),
+    path: str = "/",
+    attr_keys: Optional[List[str]] = Query(default=None),
 ):
     content = create_content(file, path)
     assert isinstance(content, ResolvedEntityContent)

--- a/h5grove/fastapi_router.py
+++ b/h5grove/fastapi_router.py
@@ -58,8 +58,8 @@ async def get_meta(
         fallback=LinkResolution.ONLY_VALID,
     )
     with h5py.File(file, "r") as h5file:
-        con = create_content(h5file, path)
-        return con.metadata()
+        content = create_content(h5file, path, resolve_links=resolve_links)
+        return content.metadata()
 
 
 @router.get("/stats/")

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,8 @@ install_requires =
 	tifffile
 
 [options.extras_require]
+fastapi = 
+    fastapi
 flask =
 	Flask
 	Flask-Compress
@@ -36,6 +38,7 @@ dev =
 	bump2version
 	check-manifest
 	flake8
+	h5grove[fastapi]
 	h5grove[flask]
 	invoke
 	mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
 [options.extras_require]
 fastapi = 
     fastapi
+	uvicorn
 flask =
 	Flask
 	Flask-Compress
@@ -78,4 +79,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-tifffile.*]
+ignore_missing_imports = True
+
+[mypy-uvicorn.*]
 ignore_missing_imports = True

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -14,7 +14,7 @@ from h5grove.models import LinkResolution
 
 def decode_response(response: BaseServer.Response, format: str = "json"):
     """Decode response content according to given format"""
-    content_type = [h[1] for h in response.headers if h[0] == "Content-Type"][0]
+    content_type = response.find_header_value("content-type")
 
     if format == "json":
         assert content_type == "application/json"
@@ -32,7 +32,7 @@ def decode_array_response(
     shape: Tuple[int],
 ) -> np.ndarray:
     """Decode data array response content according to given information"""
-    content_type = {h[0]: h[1] for h in response.headers}["Content-Type"]
+    content_type = response.find_header_value("content-type")
 
     if format == "bin":
         assert content_type == "application/octet-stream"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,10 @@ class BaseServer:
         headers: List[Tuple[str, str]]
         content: bytes
 
+        def find_header_value(self, key: str):
+            """Find header value by key (case-insensitive)"""
+            return {h[0].lower(): h[1] for h in self.headers}[key.lower()]
+
     def __init__(self, served_dir: pathlib.Path):
         self.__served_dir = served_dir
 
@@ -45,11 +49,9 @@ class BaseServer:
             response = self._get_response(url, benchmark)
 
         assert response.status == 200
-        content_lengths = [
-            header[1] for header in response.headers if header[0] == "Content-Length"
-        ]
+        content_lengths = response.find_header_value("content-length")
         if content_lengths:
-            assert len(response.content) == int(content_lengths[0])
+            assert len(response.content) == int(content_lengths)
 
         return response
 

--- a/test/test_fastapi.py
+++ b/test/test_fastapi.py
@@ -28,7 +28,6 @@ class _FastApiServer(BaseServer):
 
     def assert_404(self, url: str):
         response = self._get_response(url, lambda f: f())
-        assert "Not Found" in str(response.content)
         assert response.status == 404
 
 

--- a/test/test_fastapi.py
+++ b/test/test_fastapi.py
@@ -8,7 +8,7 @@ import pytest
 from conftest import BaseServer
 import base_test
 
-from h5grove import fastapi_router
+from h5grove.fastapi_router import router, settings
 
 # Fixtures ###
 
@@ -40,8 +40,8 @@ def fastapi_server(tmp_path_factory):
     base_dir = tmp_path_factory.mktemp("h5grove_fastapi_served").absolute()
 
     app = FastAPI()
-    fastapi_router.base_path = str(base_dir)
-    app.include_router(fastapi_router.router)
+    settings.base_dir = str(base_dir)
+    app.include_router(router)
 
     with TestClient(app) as client:
         yield _FastApiServer(base_dir, client)

--- a/test/test_fastapi.py
+++ b/test/test_fastapi.py
@@ -1,0 +1,57 @@
+"""Test fastapi router with fatapi testing"""
+import pathlib
+from typing import Callable
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+from conftest import BaseServer
+import base_test
+
+from h5grove import fastapi_router
+
+# Fixtures ###
+
+
+class _FastApiServer(BaseServer):
+    def __init__(self, served_dir: pathlib.Path, client):
+        super().__init__(served_dir)
+        self.__client = client
+
+    def _get_response(self, url: str, benchmark: Callable) -> BaseServer.Response:
+        r = benchmark(lambda: self.__client.get(url))
+        return BaseServer.Response(
+            status=r.status_code,
+            headers=r.headers.items(),
+            content=r.content,
+        )
+
+    def assert_404(self, url: str):
+        response = self._get_response(url, lambda f: f())
+        assert "Not Found" in str(response.content)
+        assert response.status == 404
+
+
+@pytest.fixture(scope="session")
+def fastapi_server(tmp_path_factory):
+    """FastAPI test client-based `server` fixture.
+
+    Provides a function to fetch endpoints from the server.
+    """
+    base_dir = tmp_path_factory.mktemp("h5grove_fastapi_served").absolute()
+
+    app = FastAPI()
+    fastapi_router.base_path = str(base_dir)
+    app.include_router(fastapi_router.router)
+
+    with TestClient(app) as client:
+        yield _FastApiServer(base_dir, client)
+
+
+# Tests ###
+
+
+class TestFastApiEndpoints(base_test.BaseTestEndpoints):
+    @pytest.fixture
+    def server(self, fastapi_server):
+        yield fastapi_server


### PR DESCRIPTION
I found that you already have "blueprints" for flask and tornado. A project I work on uses fastapi. So I figured it will be nice to have a plug n play for fastapi too. You could still do it through the WSGI middleware. But this seems cleaner. 

I must say the implementation could be better. Especially with how the /data/ endpoint handles documentation of the two return types. This could be something you could work up from.

I'm happy with the functionality at least right now. It can easily be loaded up under a route in a bigger fastapi app.

I left out docs generation and tests. This is something I believe would be better for the maintainers to setup as they like. I hope that's okay! Feel free to edit this fork however you like :)