### PR TITLE
Improve dtype for compound datasets

### DIFF
--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -232,8 +232,7 @@ components:
       description: Attribute metadata. Does not include the value.
       properties:
         dtype:
-          type: string
-          example: '>i4'
+          $ref: '#/components/schemas/dtype'
         name:
           type: string
           example: 'attr1_name'
@@ -287,8 +286,7 @@ components:
             chunks:
               $ref: '#/components/schemas/shape'
             dtype:
-              type: string
-              example: '>f4'
+              $ref: '#/components/schemas/dtype'
             filters:
               type: array
               items:
@@ -325,6 +323,14 @@ components:
               enum: ['group']
               type: string
     # Other schemas
+    dtype:
+      oneOf:
+        - type: 'string'
+          example: '<f4'
+        - type: object
+          additionalProperties:
+            type: string
+          example: { 'name': '|S10', 'age': '<i4' }
     filterInfo:
       type: object
       properties:

--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -12,6 +12,7 @@ from .utils import (
     attr_metadata,
     convert,
     get_array_stats,
+    stringify_dtype,
     get_filters,
     get_entity_from_file,
     hdf_path_join,
@@ -142,7 +143,7 @@ class DatasetContent(ResolvedEntityContent[h5py.Dataset]):
         """
         return sorted_dict(
             ("chunks", self._h5py_entity.chunks),
-            ("dtype", self._h5py_entity.dtype.str),
+            ("dtype", stringify_dtype(self._h5py_entity.dtype)),
             ("filters", get_filters(self._h5py_entity)),
             ("shape", self._h5py_entity.shape),
             *super().metadata().items(),

--- a/h5grove/models.py
+++ b/h5grove/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Tuple, Union
+from typing import Dict, Tuple, Union
 import h5py
 
 H5pyEntity = Union[
@@ -15,3 +15,6 @@ class LinkResolution(str, Enum):
         "only_valid"  # Links are only resolved if valid and unresolved if broken
     )
     ALL = "all"  # Links are resolved no matter their status. The resolution of broken links raises LinkError
+
+
+StrDtype = Union[str, Dict[str, "StrDtype"]]  # type: ignore

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -3,7 +3,7 @@ from os.path import basename
 import numpy as np
 from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
 
-from .models import H5pyEntity, LinkResolution, Selection
+from .models import H5pyEntity, LinkResolution, Selection, StrDtype
 
 
 class NotFoundError(Exception):
@@ -19,7 +19,11 @@ class LinkError(NotFoundError):
 
 
 def attr_metadata(attrId: h5py.h5a.AttrID) -> dict:
-    return {"dtype": attrId.dtype.str, "name": attrId.name, "shape": attrId.shape}
+    return {
+        "dtype": stringify_dtype(attrId.dtype),
+        "name": attrId.name,
+        "shape": attrId.shape,
+    }
 
 
 def get_entity_from_file(
@@ -244,3 +248,12 @@ def get_filter_info(
     (filter_id, _, _, name) = filter
 
     return {"id": filter_id, "name": name}
+
+
+def stringify_dtype(dtype: np.dtype) -> StrDtype:
+    if dtype.fields is None:
+        return dtype.str
+
+    return {
+        k: stringify_dtype(dtype_tuple[0]) for k, dtype_tuple in dtype.fields.items()
+    }

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -169,6 +169,33 @@ class BaseTestEndpoints:
             "type": "dataset",
         }
 
+    def test_meta_on_compound_dataset(self, server):
+        """Test /meta/ endpoint on a chunked and compressed dataset"""
+        filename = "test.h5"
+        tested_h5entity_path = "/dogs"
+
+        with h5py.File(server.served_directory / filename, mode="w") as h5file:
+            h5file.create_dataset(
+                tested_h5entity_path,
+                data=np.array(
+                    [("Rex", 9, 81.0), ("Fido", 3, 27.0)],
+                    dtype=[("name", "S10"), ("age", "i4"), ("weight", "f4")],
+                ),
+            )
+
+        response = server.get(f"/meta/?file={filename}&path={tested_h5entity_path}")
+        content = decode_response(response)
+
+        assert content == {
+            "attributes": [],
+            "chunks": None,
+            "dtype": {"name": "|S10", "age": "<i4", "weight": "<f4"},
+            "filters": None,
+            "name": "dogs",
+            "shape": [2],
+            "type": "dataset",
+        }
+
     def test_meta_on_group(self, server):
         """Test /meta/ endpoint on a group"""
         # Test condition


### PR DESCRIPTION
Let's take the [example from Numpy](https://numpy.org/doc/stable/user/basics.rec.html#introduction):

```py
with h5py.File("test.h5", "w") as h5file:
    h5file.create_dataset(
                "dogs",
                data=np.array(
                    [("Rex", 9, 81.0), ("Fido", 3, 27.0)],
                    dtype=[("name", "S10"), ("age", "i4"), ("weight", "f4")],
                ),
            )
```

When asking for the metadata, h5grove was returning:
```
{
  ...
  dtype='|V18'
}
```

Now it returns
```
{
  ...
  dtype={"name": "|S10", "age": "<i4", "weight": "<f4"}
}
```
