### PR TITLE
Return 403 on PermissionError

### DIFF
--- a/h5grove/fastapi_utils.py
+++ b/h5grove/fastapi_utils.py
@@ -51,6 +51,10 @@ async def add_base_path(file):
     filepath = f"{settings.base_dir}/{file}" if settings.base_dir else file
     if not os.path.isfile(filepath):
         raise HTTPException(status_code=404, detail="File not found!")
+    if not os.access(filepath, mode=os.R_OK):
+        raise HTTPException(
+            status_code=403, detail="Cannot read file: Permission denied"
+        )
     return filepath
 
 

--- a/h5grove/flask_utils.py
+++ b/h5grove/flask_utils.py
@@ -50,6 +50,9 @@ def get_filename(a_request: Request) -> str:
     if not os.path.isfile(full_file_path):
         abort(404, "File not found!")
 
+    if not os.access(full_file_path, mode=os.R_OK):
+        abort(403, "Cannot read file: Permission denied")
+
     return full_file_path
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -58,6 +58,9 @@ class BaseServer:
     def assert_404(self, url: str):
         raise NotImplementedError()
 
+    def assert_403(self, url: str):
+        raise NotImplementedError()
+
 
 # subprocess_server fixture  ###
 
@@ -79,6 +82,11 @@ class SubprocessServer(BaseServer):
         with pytest.raises(HTTPError) as e:
             self._get_response(url, lambda f: f())
             assert e.value.code == 404
+
+    def assert_403(self, url: str):
+        with pytest.raises(HTTPError) as e:
+            self._get_response(url, lambda f: f())
+            assert e.value.code == 403
 
 
 def get_free_tcp_port(host: str = "localhost") -> int:

--- a/test/test_fastapi.py
+++ b/test/test_fastapi.py
@@ -30,6 +30,10 @@ class _FastApiServer(BaseServer):
         response = self._get_response(url, lambda f: f())
         assert response.status == 404
 
+    def assert_403(self, url: str):
+        response = self._get_response(url, lambda f: f())
+        assert response.status == 403
+
 
 @pytest.fixture(scope="session")
 def fastapi_server(tmp_path_factory):

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -30,6 +30,10 @@ class _FlaskServer(BaseServer):
         assert "Not Found" in str(response.content)
         assert response.status == 404
 
+    def assert_403(self, url: str):
+        response = self._get_response(url, lambda f: f())
+        assert response.status == 403
+
 
 @pytest.fixture(scope="session")
 def flask_server(tmp_path_factory):

--- a/test/test_tornado.py
+++ b/test/test_tornado.py
@@ -54,6 +54,11 @@ class _TornadoServer(BaseServer):
             self._get_response(url, lambda f: f())
         assert e.value.code == 404
 
+    def assert_403(self, url: str):
+        with pytest.raises(HTTPClientError) as e:
+            self._get_response(url, lambda f: f())
+        assert e.value.code == 403
+
 
 @pytest.fixture
 def tornado_server(_base_dir, io_loop, http_client, base_url):


### PR DESCRIPTION
In `..._utils`, we return 404 if the file/entity is not found. Then, it makes sense to return 403 if the file cannot be read.