### PR TITLE
Implement paths endpoint

### DIFF
--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -120,6 +120,31 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
+  /paths:
+    get:
+      summary: Get the list of paths contained in a group
+      description: Retrieves the list of paths of entities contained in a group. Includes the group path.
+      parameters:
+        - $ref: '#/components/parameters/file'
+        - $ref: '#/components/parameters/path'
+        - $ref: '#/components/parameters/resolve_links'
+      responses:
+        '200':
+          description: Paths in the group
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/paths'
+              examples:
+                'All paths':
+                  description: 'For an file containing an empty group and a group with a dataset'
+                  value: ['/', '/group_1', '/group_2', '/group_2/dataset']
+
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+
   /stats:
     get:
       summary: Get statistics on data of a dataset
@@ -343,6 +368,10 @@ components:
     numberOrNull:
       type: number
       nullable: true
+    paths:
+      type: array
+      items:
+        type: string
     selectionItem:
       anyOf:
         - type: string

--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -15,6 +15,7 @@ from .utils import (
     attr_metadata,
     convert,
     get_array_stats,
+    open_file_with_error_fallback,
     stringify_dtype,
     get_filters,
     get_entity_from_file,
@@ -277,14 +278,7 @@ def get_content_from_file(
     resolve_links: LinkResolution = LinkResolution.ONLY_VALID,
     h5py_options: Dict[str, Any] = {},
 ):
-    try:
-        f = h5py.File(filepath, "r", **h5py_options)
-    except OSError as e:
-        if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):
-            raise create_error(404, "File not found!")
-        if isinstance(e, PermissionError) or "Permission denied" in str(e):
-            raise create_error(403, "Cannot read file: Permission denied!")
-        raise e
+    f = open_file_with_error_fallback(filepath, create_error, h5py_options)
 
     try:
         yield create_content(f, path, resolve_links)
@@ -302,14 +296,7 @@ def get_list_of_paths(
     resolve_links: LinkResolution = LinkResolution.ONLY_VALID,
     h5py_options: Dict[str, Any] = {},
 ):
-    try:
-        f = h5py.File(filepath, "r", **h5py_options)
-    except OSError as e:
-        if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):
-            raise create_error(404, "File not found!")
-        if isinstance(e, PermissionError) or "Permission denied" in str(e):
-            raise create_error(403, "Cannot read file: Permission denied!")
-        raise e
+    f = open_file_with_error_fallback(filepath, create_error, h5py_options)
 
     names = []
 

--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -292,3 +292,39 @@ def get_content_from_file(
         raise create_error(404, str(e))
     finally:
         f.close()
+
+
+@contextlib.contextmanager
+def get_list_of_paths(
+    filepath: Union[str, Path],
+    base_path: Optional[str],
+    create_error: Callable[[int, str], Exception],
+    resolve_links: LinkResolution = LinkResolution.ONLY_VALID,
+    h5py_options: Dict[str, Any] = {},
+):
+    try:
+        f = h5py.File(filepath, "r", **h5py_options)
+    except OSError as e:
+        if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):
+            raise create_error(404, "File not found!")
+        if isinstance(e, PermissionError) or "Permission denied" in str(e):
+            raise create_error(403, "Cannot read file: Permission denied!")
+        raise e
+
+    names = []
+
+    def get_path(name: str):
+        full_path = hdf_path_join(base_path, name)
+        content = create_content(f, full_path, resolve_links)
+        names.append(content.path)
+
+    try:
+        base_content = create_content(f, base_path, resolve_links)
+        assert isinstance(base_content, GroupContent)
+        names.append(base_content.path)
+        base_content._h5py_entity.visit(get_path)
+        yield names
+    except NotFoundError as e:
+        raise create_error(404, str(e))
+    finally:
+        f.close()

--- a/h5grove/fastapi_utils.py
+++ b/h5grove/fastapi_utils.py
@@ -8,6 +8,7 @@ from .content import (
     DatasetContent,
     ResolvedEntityContent,
     get_content_from_file,
+    get_list_of_paths,
 )
 from .encoders import encode
 from .models import LinkResolution
@@ -135,6 +136,23 @@ async def get_stats(
     with get_content_from_file(file, path, create_error) as content:
         assert isinstance(content, DatasetContent)
         h5grove_response = encode(content.data_stats(selection), "json")
+        return Response(
+            content=h5grove_response.content, headers=h5grove_response.headers
+        )
+
+
+@router.get("/paths/")
+async def get_paths(
+    file: str = Depends(add_base_path),
+    path: str = "/",
+    resolve_links: str = "only_valid",
+):
+    resolve_links = parse_link_resolution_arg(
+        resolve_links,
+        fallback=LinkResolution.ONLY_VALID,
+    )
+    with get_list_of_paths(file, path, create_error, resolve_links) as paths:
+        h5grove_response = encode(paths, "json")
         return Response(
             content=h5grove_response.content, headers=h5grove_response.headers
         )

--- a/h5grove/flask_utils.py
+++ b/h5grove/flask_utils.py
@@ -5,7 +5,12 @@ import os
 from typing import Any, Callable, Mapping, Optional
 
 
-from .content import DatasetContent, ResolvedEntityContent, get_content_from_file
+from .content import (
+    DatasetContent,
+    ResolvedEntityContent,
+    get_content_from_file,
+    get_list_of_paths,
+)
 from .encoders import encode
 from .models import LinkResolution
 from .utils import parse_bool_arg, parse_link_resolution_arg
@@ -15,6 +20,7 @@ __all__ = [
     "attr_route",
     "data_route",
     "meta_route",
+    "paths_route",
     "stats_route",
     "URL_RULES",
     "BLUEPRINT",
@@ -86,6 +92,18 @@ def meta_route():
         return make_encoded_response(content.metadata())
 
 
+def paths_route():
+    filename = get_filename(request)
+    path = request.args.get("path")
+    resolve_links = parse_link_resolution_arg(
+        request.args.get("resolve_links", None),
+        fallback=LinkResolution.ONLY_VALID,
+    )
+
+    with get_list_of_paths(filename, path, create_error, resolve_links) as paths:
+        return make_encoded_response(paths)
+
+
 def stats_route():
     """`/stats/` endpoint handler"""
     filename = get_filename(request)
@@ -101,6 +119,7 @@ URL_RULES = {
     "/attr/": attr_route,
     "/data/": data_route,
     "/meta/": meta_route,
+    "/paths/": paths_route,
     "/stats/": stats_route,
 }
 """Mapping of Flask URL endpoints to handlers"""

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -200,8 +200,8 @@ def get_array_stats(data: np.ndarray) -> Dict[str, Union[float, int, None]]:
     }
 
 
-def hdf_path_join(prefix, suffix):
-    if prefix == "/":
+def hdf_path_join(prefix: Union[str, None], suffix: str):
+    if prefix is None or prefix == "/":
         return f"/{suffix}"
 
     return f'{prefix.rstrip("/")}/{suffix}'

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ dev =
 	invoke
 	mypy
 	myst-parser
+	# Needed for fastapi tests. Could be removed by setting fastapi[all] as dep in the future.
+	httpx >= 0.23
 	pytest
 	pytest-benchmark
 	pytest-cov


### PR DESCRIPTION
For https://github.com/silx-kit/h5web/issues/1348, we need to implement an endpoint that either:
- search for a pattern in the file
- returns a list of paths so that the client can search inside

For now, I choose the latter solution with a new endpoints called `paths` that returns the list of all the HDF5 paths in the file. Query arg of the other endpoints were reused:
- `path`: gives the base upon which the paths are generated. Can be used to generate paths of a subtree. Defaults to `/` (root).
- `resolve_links`: whether links should be resolved. Default to `ONLY_VALID`.