### PR TITLE
Return 422 with error message on query arg errors

### DIFF
--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -46,8 +46,12 @@ paths:
                 'filtered attributes':
                   description: 'For the same entity but attr_keys was set to a1'
                   value: { a1: 5 }
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
         '500':
           $ref: '#/components/responses/500'
 
@@ -81,8 +85,12 @@ paths:
               schema:
                 type: string
 
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
         '500':
           $ref: '#/components/responses/500'
 
@@ -115,8 +123,12 @@ paths:
                     other: '#/components/schemas/resolvedEntityMetadata'
                     soft_link: '#/components/schemas/softLinkMetadata'
 
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
         '500':
           $ref: '#/components/responses/500'
 
@@ -140,8 +152,12 @@ paths:
                   description: 'For an file containing an empty group and a group with a dataset'
                   value: ['/', '/group_1', '/group_2', '/group_2/dataset']
 
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
         '500':
           $ref: '#/components/responses/500'
 
@@ -182,8 +198,12 @@ paths:
                     mean: 36,
                     std: 7.5,
                   }
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
+        '422':
+          $ref: '#/components/responses/422'
         '500':
           $ref: '#/components/responses/500'
 
@@ -409,7 +429,11 @@ components:
       value: [5, 4, 7, 8, 10, 5, 7, 8, 9, 12]
 
   responses:
+    '403':
+      description: The file is not allowed to be read.
     '404':
       description: The file was not found or the queried path does not exist in the file.
+    '422':
+      description: A query argument is invalid.
     '500':
       description: The h5py entity type is not supported.

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -5,7 +5,7 @@ import orjson
 import h5py
 import tifffile
 
-from .utils import is_numeric_data
+from .utils import QueryArgumentError, is_numeric_data
 
 
 def bin_encode(array: np.ndarray) -> bytes:
@@ -102,7 +102,7 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
         - `npy`: nD arrays in downloadable npy files
         - `tiff`: 2D arrays in downloadable TIFF files
     :returns: A Response object containing content and headers
-    :raises ValueError: If encoding is not among the ones above.
+    :raises QueryArgumentError: If encoding is not among the ones above.
     """
     if encoding in ("json", None):
         return Response(
@@ -112,7 +112,9 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
 
     content_array = np.array(content, copy=False)
     if not is_numeric_data(content_array):
-        raise ValueError(f"Unsupported encoding {encoding} for non-numeric content")
+        raise QueryArgumentError(
+            f"Unsupported encoding {encoding} for non-numeric content"
+        )
 
     if encoding == "bin":
         return Response(
@@ -149,4 +151,4 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
             },
         )
 
-    raise ValueError(f"Unsupported encoding {encoding}")
+    raise QueryArgumentError(f"Unsupported encoding {encoding}")

--- a/h5grove/fastapi_utils.py
+++ b/h5grove/fastapi_utils.py
@@ -11,8 +11,6 @@ from .content import (
     get_list_of_paths,
 )
 from .encoders import encode
-from .models import LinkResolution
-from .utils import parse_link_resolution_arg
 
 __all__ = [
     "router",
@@ -117,10 +115,7 @@ async def get_meta(
     resolve_links: str = "only_valid",
 ):
     """`/meta/` endpoint handler"""
-    resolve_links = parse_link_resolution_arg(
-        resolve_links,
-        fallback=LinkResolution.ONLY_VALID,
-    )
+
     with get_content_from_file(file, path, create_error, resolve_links) as content:
         h5grove_response = encode(content.metadata(), "json")
         return Response(
@@ -147,10 +142,6 @@ async def get_paths(
     path: str = "/",
     resolve_links: str = "only_valid",
 ):
-    resolve_links = parse_link_resolution_arg(
-        resolve_links,
-        fallback=LinkResolution.ONLY_VALID,
-    )
     with get_list_of_paths(file, path, create_error, resolve_links) as paths:
         h5grove_response = encode(paths, "json")
         return Response(

--- a/h5grove/flask_utils.py
+++ b/h5grove/flask_utils.py
@@ -12,8 +12,7 @@ from .content import (
     get_list_of_paths,
 )
 from .encoders import encode
-from .models import LinkResolution
-from .utils import parse_bool_arg, parse_link_resolution_arg
+from .utils import parse_bool_arg
 
 
 __all__ = [
@@ -83,10 +82,7 @@ def meta_route():
     """`/meta/` endpoint handler"""
     filename = get_filename(request)
     path = request.args.get("path")
-    resolve_links = parse_link_resolution_arg(
-        request.args.get("resolve_links", None),
-        fallback=LinkResolution.ONLY_VALID,
-    )
+    resolve_links = request.args.get("resolve_links", None)
 
     with get_content_from_file(filename, path, create_error, resolve_links) as content:
         return make_encoded_response(content.metadata())
@@ -95,10 +91,7 @@ def meta_route():
 def paths_route():
     filename = get_filename(request)
     path = request.args.get("path")
-    resolve_links = parse_link_resolution_arg(
-        request.args.get("resolve_links", None),
-        fallback=LinkResolution.ONLY_VALID,
-    )
+    resolve_links = request.args.get("resolve_links", None)
 
     with get_list_of_paths(filename, path, create_error, resolve_links) as paths:
         return make_encoded_response(paths)

--- a/h5grove/tornado_utils.py
+++ b/h5grove/tornado_utils.py
@@ -12,8 +12,7 @@ from .content import (
     get_list_of_paths,
 )
 from .encoders import Response, encode
-from .models import LinkResolution
-from .utils import parse_bool_arg, parse_link_resolution_arg
+from .utils import parse_bool_arg
 
 __all__ = [
     "BaseHandler",
@@ -44,12 +43,10 @@ class BaseHandler(RequestHandler):
         path = self.get_query_argument("path", None, strip=False)
 
         full_file_path = os.path.join(self.base_dir, file_path)
-        resolve_links = parse_link_resolution_arg(
-            self.get_query_argument("resolve_links", None),
-            fallback=LinkResolution.ONLY_VALID,
-        )
 
-        response = self.get_response(full_file_path, path, resolve_links)
+        response = self.get_response(
+            full_file_path, path, self.get_query_argument("resolve_links", None)
+        )
 
         for key, value in response.headers.items():
             self.set_header(key, value)
@@ -58,7 +55,7 @@ class BaseHandler(RequestHandler):
         self.finish()
 
     def get_response(
-        self, full_file_path: str, path: Optional[str], resolve_links: LinkResolution
+        self, full_file_path: str, path: Optional[str], resolve_links: Optional[str]
     ) -> Response:
         raise NotImplementedError
 
@@ -73,7 +70,7 @@ class BaseHandler(RequestHandler):
 
 class ContentHandler(BaseHandler):
     def get_response(
-        self, full_file_path: str, path: Optional[str], resolve_links: LinkResolution
+        self, full_file_path: str, path: Optional[str], resolve_links: Optional[str]
     ) -> Response:
         with get_content_from_file(
             full_file_path, path, create_error, resolve_links
@@ -132,7 +129,7 @@ class StatisticsHandler(ContentHandler):
 
 class PathsHandler(BaseHandler):
     def get_response(
-        self, full_file_path: str, path: Optional[str], resolve_links: LinkResolution
+        self, full_file_path: str, path: Optional[str], resolve_links: Optional[str]
     ) -> Response:
         with get_list_of_paths(
             full_file_path, path, create_error, resolve_links

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -20,6 +20,10 @@ class LinkError(NotFoundError):
     pass
 
 
+class QueryArgumentError(ValueError):
+    pass
+
+
 def _get_attr_id(entity_attrs: h5py.AttributeManager, attr_name: str):
     return entity_attrs.get_id(attr_name)
 
@@ -163,13 +167,18 @@ def convert(data: T, dtype: Optional[str] = "origin") -> T:
 
     if dtype == "safe":
         if not is_numeric_data(data):
-            raise ValueError(f"Unsupported dtype {dtype} for non-numeric content")
+            raise QueryArgumentError(
+                f"Unsupported dtype {dtype} for non-numeric content"
+            )
         return data.astype(_sanitize_dtype(data.dtype), order="C", copy=False)
 
-    raise ValueError(f"Unsupported dtype {dtype}")
+    raise QueryArgumentError(f"Unsupported dtype {dtype}")
 
 
-def is_numeric_data(data: Union[np.ndarray, np.number, np.bool_]) -> bool:
+def is_numeric_data(data: Union[np.ndarray, np.number, np.bool_, bytes]) -> bool:
+    if not isinstance(data, (np.ndarray, np.number, np.bool_)):
+        return False
+
     return np.issubdtype(data.dtype, np.number) or np.issubdtype(data.dtype, np.bool_)
 
 
@@ -233,8 +242,8 @@ def parse_link_resolution_arg(
     if query_arg == LinkResolution.ONLY_VALID:
         return LinkResolution.ONLY_VALID
 
-    raise ValueError(
-        f"{raw_query_arg} is not a valid value for link resolution. Accepted values are: {LinkResolution.ALL}, f{LinkResolution.NONE} or {LinkResolution.ONLY_VALID}"
+    raise QueryArgumentError(
+        f"{raw_query_arg} is not a valid value for link resolution. Accepted values are: {LinkResolution.ALL}, {LinkResolution.NONE} or {LinkResolution.ONLY_VALID}"
     )
 
 

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -322,21 +322,21 @@ class BaseTestEndpoints:
         with h5py.File(server.served_directory / filename, mode="w") as h5file:
             h5file["data"] = 0
 
-        server.assert_404(f"/attr/?file={filename}&path={not_a_path}")
-        server.assert_404(f"/data/?file={filename}&path={not_a_path}")
-        server.assert_404(f"/meta/?file={filename}&path={not_a_path}")
-        server.assert_404(f"/paths/?file={filename}&path={not_a_path}")
-        server.assert_404(f"/stats/?file={filename}&path={not_a_path}")
+        server.assert_error_code(f"/attr/?file={filename}&path={not_a_path}", 404)
+        server.assert_error_code(f"/data/?file={filename}&path={not_a_path}", 404)
+        server.assert_error_code(f"/meta/?file={filename}&path={not_a_path}", 404)
+        server.assert_error_code(f"/paths/?file={filename}&path={not_a_path}", 404)
+        server.assert_error_code(f"/stats/?file={filename}&path={not_a_path}", 404)
 
     def test_404_on_non_existing_file(self, server):
         filename = "not_a_file.h5"
         path = "/"
 
-        server.assert_404(f"/attr/?file={filename}&path={path}")
-        server.assert_404(f"/data/?file={filename}&path={path}")
-        server.assert_404(f"/meta/?file={filename}&path={path}")
-        server.assert_404(f"/paths/?file={filename}&path={path}")
-        server.assert_404(f"/stats/?file={filename}&path={path}")
+        server.assert_error_code(f"/attr/?file={filename}&path={path}", 404)
+        server.assert_error_code(f"/data/?file={filename}&path={path}", 404)
+        server.assert_error_code(f"/meta/?file={filename}&path={path}", 404)
+        server.assert_error_code(f"/paths/?file={filename}&path={path}", 404)
+        server.assert_error_code(f"/stats/?file={filename}&path={path}", 404)
 
     @pytest.mark.parametrize(
         "resolve_links",
@@ -352,7 +352,7 @@ class BaseTestEndpoints:
 
         # It should return 404 if trying to resolve the broken link
         if resolve_links == LinkResolution.ALL:
-            server.assert_404(url)
+            server.assert_error_code(url, 404)
         # It should return the link metadata when not resolving the link (resolve_links set to NONE or ONLY_VALID)
         else:
             response = server.get(url)
@@ -375,8 +375,8 @@ class BaseTestEndpoints:
             mode=stat.S_IWUSR,
         )
 
-        server.assert_403(f"/attr/?file={filename}&path={path}")
-        server.assert_403(f"/data/?file={filename}&path={path}")
-        server.assert_403(f"/meta/?file={filename}&path={path}")
-        server.assert_403(f"/paths/?file={filename}&path={path}")
-        server.assert_403(f"/stats/?file={filename}&path={path}")
+        server.assert_error_code(f"/attr/?file={filename}&path={path}", 403)
+        server.assert_error_code(f"/data/?file={filename}&path={path}", 403)
+        server.assert_error_code(f"/meta/?file={filename}&path={path}", 403)
+        server.assert_error_code(f"/paths/?file={filename}&path={path}", 403)
+        server.assert_error_code(f"/stats/?file={filename}&path={path}", 403)

--- a/test/test_tornado.py
+++ b/test/test_tornado.py
@@ -6,7 +6,7 @@ from tornado.httpclient import HTTPClientError
 import tornado.web
 
 from conftest import BaseServer
-from test_utils import Response, decode_response
+from test_utils import Response, assert_error_response
 import base_test
 
 from h5grove.tornado_utils import get_handlers
@@ -50,27 +50,19 @@ class _TornadoServer(BaseServer):
             status=r.code, headers=list(r.headers.get_all()), content=r.body
         )
 
-    def assert_404(self, url: str):
-        with pytest.raises(HTTPClientError) as exc:
+    def assert_error_code(self, url: str, error_code: int):
+        with pytest.raises(HTTPClientError) as e:
             self._get_response(url, lambda f: f())
-        r = exc.value.response
+        r = e.value.response
         assert r is not None
-
-        res = Response(status=r.code, headers=list(r.headers.get_all()), content=r.body)
-        assert res.status == 404
-        content = decode_response(res)
-        assert isinstance(content, dict) and isinstance(content["message"], str)
-
-    def assert_403(self, url: str):
-        with pytest.raises(HTTPClientError) as exc:
-            self._get_response(url, lambda f: f())
-        r = exc.value.response
-        assert r is not None
-
-        res = Response(status=r.code, headers=list(r.headers.get_all()), content=r.body)
-        assert res.status == 403
-        content = decode_response(res)
-        assert isinstance(content, dict) and isinstance(content["message"], str)
+        assert_error_response(
+            Response(
+                status=r.code,
+                headers=list(r.headers.get_all()),
+                content=r.body,
+            ),
+            error_code,
+        )
 
 
 @pytest.fixture

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 from typing import List, NamedTuple, Tuple
 
-from h5grove.utils import hdf_path_join
+from h5grove.utils import QueryArgumentError, hdf_path_join
 
 
 class Response(NamedTuple):
@@ -40,7 +40,7 @@ def decode_response(response: Response, format: str = "json"):
     if format == "npy":
         assert content_type == "application/octet-stream"
         return np.load(io.BytesIO(response.content))
-    raise ValueError(f"Unsupported format: {format}")
+    raise QueryArgumentError(f"Unsupported format: {format}")
 
 
 def decode_array_response(
@@ -57,3 +57,9 @@ def decode_array_response(
         return np.frombuffer(response.content, dtype=dtype).reshape(shape)
 
     return np.array(decode_response(response, format), copy=False)
+
+
+def assert_error_response(response: Response, error_code: int):
+    assert response.status == error_code
+    content = decode_response(response)
+    assert isinstance(content, dict) and isinstance(content["message"], str)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 from typing import List, NamedTuple, Tuple
 
-from h5grove.utils import QueryArgumentError, hdf_path_join
+from h5grove.utils import hdf_path_join
 
 
 class Response(NamedTuple):
@@ -40,7 +40,7 @@ def decode_response(response: Response, format: str = "json"):
     if format == "npy":
         assert content_type == "application/octet-stream"
         return np.load(io.BytesIO(response.content))
-    raise QueryArgumentError(f"Unsupported format: {format}")
+    raise ValueError(f"Unsupported format: {format}")
 
 
 def decode_array_response(


### PR DESCRIPTION
A discussion with Valentin showed me that the server was returning 500 errors when the query arguments were invalid (i.e. not expected or malformed).

As this error is a bit cryptic for end-users, I tried to improve this by adding a new kind of error `QueryArgumentError` that is used to return [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) when query arguments do not match what h5grove expects (following the recommendation in https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required).

I also had to refactor the tests to be able to test for this new error code (done in a separate commit)