### PR TITLE
Provide more metadata for HDF5 types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 pip install -e .[dev]
 ```
 
-will install `h5grove` in editable mode with all the linting/formating/testing packages. This will also install the [flask](https://flask.palletsprojects.com/en/) and [tornado](https://www.tornadoweb.org/en/stable/) packages as they are needed to build the documentation.
+will install `h5grove` in editable mode with all the linting/formating/testing packages. This will also install the [fastapi](https://fastapi.tiangolo.com/), [flask](https://flask.palletsprojects.com/en/) and [tornado](https://www.tornadoweb.org/en/stable/) packages as they are needed to build the documentation and test the project.
 
 ## Linting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@
 pip install -e .[dev]
 ```
 
-will install `h5grove` in editable mode with all the linting/formating/testing packages. This will also [flask](https://flask.palletsprojects.com/en/) and [tornado](https://www.tornadoweb.org/en/stable/) packages as they are needed to build the documentation.
+will install `h5grove` in editable mode with all the linting/formating/testing packages. This will also install the [flask](https://flask.palletsprojects.com/en/) and [tornado](https://www.tornadoweb.org/en/stable/) packages as they are needed to build the documentation.
 
 ## Linting
 

--- a/docs/_static/api.yaml
+++ b/docs/_static/api.yaml
@@ -270,50 +270,51 @@ components:
         mixed:
           description: Gets data[5, 0:10:2]
           value: [5, '0:10:2']
+
   schemas:
     # Metadata schemas
     attrMetadata:
       type: object
       description: Attribute metadata. Does not include the value.
       properties:
-        dtype:
-          $ref: '#/components/schemas/dtype'
         name:
           type: string
           example: 'attr1_name'
         shape:
           $ref: '#/components/schemas/shape'
+        type:
+          $ref: '#/components/schemas/type'
     entityMetadata:
       type: object
       properties:
+        kind:
+          enum: ['other']
+          type: string
         name:
           type: string
           example: 'entity_name'
-        type:
-          enum: ['other']
-          type: string
     softLinkMetadata:
       allOf:
         - $ref: '#/components/schemas/entityMetadata'
         - type: object
           properties:
+            kind:
+              enum: ['soft_link']
+              type: string
             target_path:
               type: string
               example: '/path/to/linked/entity'
-            type:
-              enum: ['soft_link']
-              type: string
     externalLinkMetadata:
       allOf:
         - $ref: '#/components/schemas/softLinkMetadata'
         - type: object
           properties:
-            target_file:
-              type: string
-            type:
+            kind:
               enum: ['external_link']
               type: string
               example: 'path/to/another/file.h5'
+            target_file:
+              type: string
     resolvedEntityMetadata:
       allOf:
         - $ref: '#/components/schemas/entityMetadata'
@@ -328,25 +329,28 @@ components:
         - $ref: '#/components/schemas/resolvedEntityMetadata'
         - type: object
           properties:
+            kind:
+              enum: ['dataset']
+              type: string
+            shape:
+              $ref: '#/components/schemas/shape'
+            type:
+              $ref: '#/components/schemas/type'
             chunks:
               $ref: '#/components/schemas/shape'
-            dtype:
-              $ref: '#/components/schemas/dtype'
             filters:
               type: array
               items:
                 $ref: '#/components/schemas/filterInfo'
               nullable: true
-            shape:
-              $ref: '#/components/schemas/shape'
-            type:
-              enum: ['dataset']
-              type: string
     groupMetadata:
       allOf:
         - $ref: '#/components/schemas/resolvedEntityMetadata'
         - type: object
           properties:
+            kind:
+              enum: ['group']
+              type: string
             children:
               type: array
               items:
@@ -356,18 +360,49 @@ components:
                   - $ref: '#/components/schemas/externalLinkMetadata'
                   - $ref: '#/components/schemas/resolvedEntityMetadata'
                   - $ref: '#/components/schemas/softLinkMetadata'
-            type:
-              enum: ['group']
-              type: string
     childGroupMetadata:
       allOf:
         - $ref: '#/components/schemas/resolvedEntityMetadata'
         - type: object
           properties:
-            type:
+            kind:
               enum: ['group']
               type: string
+
     # Other schemas
+    type:
+      type: object
+      properties:
+        class:
+          type: integer
+        dtype:
+          $ref: '#/components/schemas/dtype'
+        size:
+          type: integer
+        order:
+          type: integer
+        sign:
+          type: integer
+        cset:
+          type: integer
+        vlen:
+          type: boolean
+        tag:
+          type: string
+        dims:
+          $ref: '#/components/schemas/shape'
+        dims:
+          $ref: '#/components/schemas/shape'
+        members:
+          oneOf:
+            - type: object
+              additionalProperties:
+                $ref: '#/components/schemas/type'
+            - type: object
+              additionalProperties:
+                type: integer
+        base:
+          $ref: '#/components/schemas/type'
     dtype:
       oneOf:
         - type: 'string'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ import h5grove  # noqa
 # -- Project information -----------------------------------------------------
 
 project = "h5grove"
-copyright = "2021, ESRF"
+copyright = "2024, ESRF"
 author = "ESRF"
 
 # The full version, including alpha/beta/rc tags

--- a/h5grove/fastapi_utils.py
+++ b/h5grove/fastapi_utils.py
@@ -1,4 +1,5 @@
 """Helpers for usage with `FastAPI <https://fastapi.tiangolo.com/>`_"""
+
 from fastapi import APIRouter, Depends, Response, Query, Request
 from fastapi.routing import APIRoute
 from pydantic_settings import BaseSettings

--- a/h5grove/flask_utils.py
+++ b/h5grove/flask_utils.py
@@ -1,4 +1,5 @@
 """Helpers for usage with `Flask <https://flask.palletsprojects.com/>`_"""
+
 from werkzeug.exceptions import HTTPException
 from flask import Blueprint, current_app, request, Response, Request
 import os

--- a/h5grove/models.py
+++ b/h5grove/models.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from typing import Dict, Tuple, Union
+from typing_extensions import TypedDict
 import h5py
 
 H5pyEntity = Union[
@@ -19,3 +20,22 @@ class LinkResolution(str, Enum):
 
 # Recursive types not supported by mypy: https://github.com/python/mypy/issues/731
 StrDtype = Union[str, Dict[str, "StrDtype"]]  # type: ignore
+
+# https://api.h5py.org/h5t.html
+TypeMetadata = TypedDict(
+    "TypeMetadata",
+    {
+        "class": int,  # HDF5 class code
+        "dtype": StrDtype,  # Numpy-style dtype
+        "size": int,  # all (but most relevant for int, float, string)
+        "order": int,  # int, float, bitfield
+        "sign": int,  # int
+        "cset": int,  # string
+        "vlen": bool,  # string
+        "tag": str,  # opaque
+        "dims": Tuple[int, ...],  # array
+        "members": Union[Dict[str, "TypeMetadata"], Dict[str, int]],  # compound, enum
+        "base": "TypeMetadata",  # array, enum, vlen
+    },
+    total=False,
+)

--- a/h5grove/tornado_utils.py
+++ b/h5grove/tornado_utils.py
@@ -1,4 +1,5 @@
 """Helpers for usage with `Tornado <https://www.tornadoweb.org>`_"""
+
 import os
 from typing import Any, Optional
 

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -170,9 +170,9 @@ def get_type_metadata(type_id: h5py.h5t.TypeID) -> TypeMetadata:
 
     if isinstance(type_id, h5py.h5t.TypeEnumID):
         for i in range(0, type_id.get_nmembers()):
-            members[
-                type_id.get_member_name(i).decode("utf-8")
-            ] = type_id.get_member_value(i)
+            members[type_id.get_member_name(i).decode("utf-8")] = (
+                type_id.get_member_value(i)
+            )
 
         return {
             **base_metadata,
@@ -267,12 +267,14 @@ def get_array_stats(data: np.ndarray) -> Dict[str, Union[float, int, None]]:
     strict_positive_data = data[data > 0]
     positive_data = data[data >= 0]
     return {
-        "strict_positive_min": cast(np.min(strict_positive_data))
-        if strict_positive_data.size != 0
-        else None,
-        "positive_min": cast(np.min(positive_data))
-        if positive_data.size != 0
-        else None,
+        "strict_positive_min": (
+            cast(np.min(strict_positive_data))
+            if strict_positive_data.size != 0
+            else None
+        ),
+        "positive_min": (
+            cast(np.min(positive_data)) if positive_data.size != 0 else None
+        ),
         "min": cast(np.min(data)),
         "max": cast(np.max(data)),
         "mean": cast(np.mean(data)),

--- a/h5grove/utils.py
+++ b/h5grove/utils.py
@@ -5,7 +5,7 @@ from os.path import basename
 import numpy as np
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
-from .models import H5pyEntity, LinkResolution, Selection, StrDtype
+from .models import H5pyEntity, LinkResolution, Selection, StrDtype, TypeMetadata
 
 
 class NotFoundError(Exception):
@@ -43,9 +43,9 @@ def attr_metadata(entity_attrs: h5py.AttributeManager, attr_name: str) -> dict:
     attrId = get_attr_id(entity_attrs, attr_name)
 
     return {
-        "dtype": stringify_dtype(attrId.dtype),
         "name": attr_name,
         "shape": attrId.shape,
+        "type": get_type_metadata(attrId.get_type()),
     }
 
 
@@ -123,7 +123,74 @@ def parse_slice_member(slice_member: str) -> Union[slice, int]:
 
 
 def sorted_dict(*args: Tuple[str, Any]):
-    return dict(sorted(args))
+    return dict(sorted(args, key=lambda entry: entry[0]))
+
+
+def get_type_metadata(type_id: h5py.h5t.TypeID) -> TypeMetadata:
+    base_metadata: TypeMetadata = {
+        "class": type_id.get_class(),
+        "dtype": stringify_dtype(type_id.dtype),
+        "size": type_id.get_size(),
+    }
+    members = {}
+
+    if isinstance(type_id, h5py.h5t.TypeIntegerID):
+        return {
+            **base_metadata,
+            "order": type_id.get_order(),
+            "sign": type_id.get_sign(),
+        }
+
+    if isinstance(type_id, h5py.h5t.TypeFloatID):
+        return {
+            **base_metadata,
+            "order": type_id.get_order(),
+        }
+
+    if isinstance(type_id, h5py.h5t.TypeStringID):
+        return {
+            **base_metadata,
+            "cset": type_id.get_cset(),
+            "vlen": type_id.is_variable_str(),
+        }
+
+    if isinstance(type_id, h5py.h5t.TypeBitfieldID):
+        return {**base_metadata, "order": type_id.get_order()}
+
+    if isinstance(type_id, h5py.h5t.TypeOpaqueID):
+        return {**base_metadata, "tag": type_id.get_tag()}
+
+    if isinstance(type_id, h5py.h5t.TypeCompoundID):
+        for i in range(0, type_id.get_nmembers()):
+            members[type_id.get_member_name(i).decode("utf-8")] = get_type_metadata(
+                type_id.get_member_type(i)
+            )
+
+        return {**base_metadata, "members": members}
+
+    if isinstance(type_id, h5py.h5t.TypeEnumID):
+        for i in range(0, type_id.get_nmembers()):
+            members[
+                type_id.get_member_name(i).decode("utf-8")
+            ] = type_id.get_member_value(i)
+
+        return {
+            **base_metadata,
+            "members": members,
+            "base": get_type_metadata(type_id.get_super()),
+        }
+
+    if isinstance(type_id, h5py.h5t.TypeVlenID):
+        return {**base_metadata, "base": get_type_metadata(type_id.get_super())}
+
+    if isinstance(type_id, h5py.h5t.TypeArrayID):
+        return {
+            **base_metadata,
+            "dims": type_id.get_array_dims(),
+            "base": get_type_metadata(type_id.get_super()),
+        }
+
+    return base_metadata
 
 
 def _sanitize_dtype(dtype: np.dtype) -> np.dtype:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
 
 [options.extras_require]
 fastapi = 
-    fastapi
+	fastapi
 	pydantic > 2
 	pydantic-settings
 	uvicorn
@@ -35,7 +35,7 @@ flask =
 	Flask-Compress
 	Flask-Cors
 tornado =
-    tornado
+	tornado
 dev = 
 	black
 	bump2version
@@ -43,6 +43,7 @@ dev =
 	flake8
 	h5grove[fastapi]
 	h5grove[flask]
+	h5grove[tornado]
 	invoke
 	mypy
 	myst-parser

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,6 @@ dev =
 	myst-parser
 	# Needed for fastapi tests. Could be removed by setting fastapi[all] as dep in the future.
 	httpx >= 0.23
-	pydantic_settings
 	pytest
 	pytest-benchmark
 	pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ dev =
 	myst-parser
 	# Needed for fastapi tests. Could be removed by setting fastapi[all] as dep in the future.
 	httpx >= 0.23
+	pydantic_settings
 	pytest
 	pytest-benchmark
 	pytest-cov
@@ -70,7 +71,7 @@ per-file-ignores =
     __init__.py: F401
 
 [mypy]
-python_version = 3.6
+python_version = 3.8
 
 [mypy-h5py.*]
 ignore_missing_imports = True

--- a/tasks.py
+++ b/tasks.py
@@ -32,9 +32,14 @@ def lint(c):
 
 
 @task
-def test(c):
+def test(c, verbose=False, keyword="", cov_lines=False):
     """Test without benchmark"""
-    c.run("pytest --benchmark-skip")
+    c.run(
+        "pytest --benchmark-skip"
+        + (" -vv" if verbose else "")
+        + ((" -k" + keyword) if keyword else "")
+        + (" --cov-report term-missing" if cov_lines else "")
+    )
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -37,7 +37,7 @@ def test(c, verbose=False, keyword="", cov_lines=False):
     c.run(
         "pytest --benchmark-skip"
         + (" -vv" if verbose else "")
-        + ((" -k" + keyword) if keyword else "")
+        + (f" -k{keyword}" if keyword else "")
         + (" --cov-report term-missing" if cov_lines else "")
     )
 

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -1,4 +1,5 @@
 """Base class for testing with different servers"""
+
 import os
 import stat
 from typing import Generator

--- a/test/base_test.py
+++ b/test/base_test.py
@@ -133,12 +133,12 @@ class BaseTestEndpoints:
 
         assert content == {
             "attributes": [],
-            "filters": [{"id": 2, "name": "shuffle"}, {"id": 1, "name": "deflate"}],
             "chunks": [5, 5],
-            "name": "data",
             "dtype": "<f8",
+            "filters": [{"id": 2, "name": "shuffle"}, {"id": 1, "name": "deflate"}],
+            "kind": "dataset",
+            "name": "data",
             "shape": [10, 10],
-            "type": "dataset",
         }
 
     def test_meta_on_compound_dataset(self, server):
@@ -212,10 +212,10 @@ class BaseTestEndpoints:
         # Valid link is not resolved only if link resolution is 'none'.
         if resolve_links == LinkResolution.NONE:
             assert content == {
+                "kind": "external_link",
                 "name": "ext_link",
                 "target_file": "source.h5",
                 "target_path": "data",
-                "type": "external_link",
             }
         else:
             assert content == {
@@ -223,9 +223,9 @@ class BaseTestEndpoints:
                 "chunks": None,
                 "dtype": "<f8",
                 "filters": None,
+                "kind": "dataset",
                 "name": "ext_link",
                 "shape": [10],
-                "type": "dataset",
             }
 
     def test_stats_on_negative_scalar(self, server):

--- a/test/test_benchmark_data.py
+++ b/test/test_benchmark_data.py
@@ -1,4 +1,5 @@
 """Benchmark data requests with server apps in example/ folder"""
+
 import pathlib
 from typing import Generator
 from urllib.parse import urlencode

--- a/test/test_fastapi.py
+++ b/test/test_fastapi.py
@@ -1,4 +1,5 @@
 """Test fastapi_utils with fastapi testing"""
+
 import pathlib
 from typing import Callable
 from fastapi import FastAPI

--- a/test/test_flask.py
+++ b/test/test_flask.py
@@ -1,4 +1,5 @@
 """Test flask_utils blueprint with Flask testing"""
+
 import pathlib
 from typing import Callable
 from flask import Flask

--- a/test/test_tornado.py
+++ b/test/test_tornado.py
@@ -1,4 +1,5 @@
 """Test tornado_utils using pytest-tornado"""
+
 import pathlib
 from typing import Callable
 import pytest


### PR DESCRIPTION
The new [snapshot test](https://github.com/silx-kit/h5web/blob/main/packages/app/src/providers/h5grove/__snapshots__/h5grove-api.test.ts.snap) of `H5GroveApi` in H5Web reveals that a lot of advanced HDF5 types are incorrectly parsed or simply marked as unknown.

This is due to the fact that h5grove's `/meta/` endpoint currently provides only a very basic `dtype` string (or dict of `dtype` strings for compound datasets), which is not sufficient and sometimes inaccurate (e.g. `|O` for variable-length ASCII strings instead of `|S`).

Following h5py's [low-level API](https://api.h5py.org/h5t.html) and taking inspiration from [h5wasm](https://github.com/usnistgov/h5wasm/blob/main/src/hdf5_util.cc#L245), I modify the dataset/attribute metadata response to include a `type` dictionary with all the interesting information about the dataset/attribute's HDF5 type.

Unfortunately, the `type` property was already used for the entity kind ("dataset", "group", etc.). I've renamed the existing property to `kind` to match what we do in H5Web. I've also moved the previous `dtype` property inside the new `type` dictionary (I think it's still worth keeping, as some applications may prefer to avoid parsing the full type metadata). Of course, these are both breaking changes for h5grove, which is not ideal. I'm open to suggestions if that's a no-go.