### PR TITLE
Allow `bin` format for non-numeric content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,14 @@ Tests are handled with [pytest](https://docs.pytest.org/en/stable/index.html). T
 Once `h5grove` is installed in editable mode, run the tests with
 
 ```
-invoke test
+invoke test [--options]
 ```
+
+Available options (cf. `invoke --help test`):
+
+- `-c`, `--cov-lines`: display line numbers in coverage report
+- `-k [keyword]`, `--keyword [keyword]`: filter tests by keyword
+- `-v`, `--verbose`: enable verbose test output
 
 ### Benchmarks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Tests are handled with [pytest](https://docs.pytest.org/en/stable/index.html). T
 Once `h5grove` is installed in editable mode, run the tests with
 
 ```
-invoke test [--options]
+invoke test
 ```
 
 Available options (cf. `invoke --help test`):

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -111,10 +111,6 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
         )
 
     content_array = np.array(content, copy=False)
-    if not is_numeric_data(content_array):
-        raise QueryArgumentError(
-            f"Unsupported encoding {encoding} for non-numeric content"
-        )
 
     if encoding == "bin":
         return Response(
@@ -122,6 +118,11 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
             headers={
                 "Content-Type": "application/octet-stream",
             },
+        )
+
+    if not is_numeric_data(content_array):
+        raise QueryArgumentError(
+            f"Unsupported encoding {encoding} for non-numeric content"
         )
 
     if encoding == "csv":

--- a/tasks.py
+++ b/tasks.py
@@ -31,7 +31,7 @@ def lint(c):
     mypy(c)
 
 
-@task
+@task(optional=["verbose", "keyword", "cov-lines"])
 def test(c, verbose=False, keyword="", cov_lines=False):
     """Test without benchmark"""
     c.run(


### PR DESCRIPTION
Fetching an opaque binary dataset with `format=bin` was throwing a 422 error.