### PR TITLE
Fix serialization of complex256 objects to JSON

### DIFF
--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -4,6 +4,7 @@ import numpy as np
 import orjson
 import h5py
 import tifffile
+import numbers
 
 from .utils import QueryArgumentError, is_numeric_data
 
@@ -23,10 +24,10 @@ def orjson_default(o: Any) -> Union[list, float, str, None]:
     if isinstance(o, np.number) and o.dtype.kind == "f" and o.itemsize > 8:
         # Force conversion of float >64bits to native float even if it means losing precision
         return float(o)
+    if isinstance(o, numbers.Complex):
+        return [o.real, o.imag]
     if isinstance(o, (np.generic, np.ndarray)):
         return o.tolist()
-    if isinstance(o, complex):
-        return [o.real, o.imag]
     if isinstance(o, h5py.Empty):
         return None
     if isinstance(o, bytes):


### PR DESCRIPTION
1. https://h5web.panosc.eu/h5grove?file=sample.h5
2. Select `/complex256_scalar` or `/complex256_2D`
3. 500 error

h5grove fails in `encoders.py`, when serializing `complex256` values to JSON with [orjson](https://github.com/silx-kit/h5grove/blob/main/h5grove/encoders.py#L48). There's an infinite recursion call in `orjson_default`, on [line 27](https://github.com/silx-kit/h5grove/blob/main/h5grove/encoders.py#L27).

With `complex64` or `complex128` scalars, I trace two calls to `orjson_default`:
1. During the first call, the condition that matches first is `isinstance(o, (np.generic, np.ndarray))` => `o.tolist()` is called and returned.
2. This triggers a second call, during which the condition that matches first is now `isinstance(o, complex)` => `[o.real, o.imag]` is returned.

With `complex256`, the first call is the same, but on the second call, the condition that matches is again `isinstance(o, (np.generic, np.ndarray))` so we recurse infinitely.

If I move the complex condition first, then `o.tolist()` is never called for `complex64` and `complex128` numbers (i.e. there's only one call to `orjson_default`). I can then change the condition to `isinstance(o, numbers.Complex)` to also match `complex256` and the infinite recursion issue is gone.
