### PR TITLE
Allow copy for scalar and nested sequences when converting data to numpy arrays

### DIFF
--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -190,7 +190,7 @@ class DatasetContent(ResolvedEntityContent[h5py.Dataset]):
         return get_array_stats(data)
 
     def _get_finite_data(self, selection: Selection) -> np.ndarray:
-        data = np.array(self.data(selection), copy=False)  # So it works with scalars
+        data = np.asarray(self.data(selection))  # So it works with scalars
 
         if not np.issubdtype(data.dtype, np.floating):
             return data

--- a/h5grove/content.py
+++ b/h5grove/content.py
@@ -288,6 +288,7 @@ def get_content_from_file(
             fallback=LinkResolution.ONLY_VALID,
         )
     except QueryArgumentError as e:
+        f.close()
         raise create_error(422, str(e))
 
     try:

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -126,21 +126,26 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
             f"Unsupported encoding {encoding} for non-numeric content"
         )
 
-    if encoding == "csv":
-        return Response(
-            csv_encode(content_array),
-            headers={
-                "Content-Type": "text/csv",
-                "Content-Disposition": 'attachment; filename="data.csv"',
-            },
-        )
-
     if encoding == "npy":
         return Response(
             npy_encode(content_array),
             headers={
                 "Content-Type": "application/octet-stream",
                 "Content-Disposition": 'attachment; filename="data.npy"',
+            },
+        )
+
+    if content_array.ndim == 0:
+        raise QueryArgumentError(
+            f"Unsupported encoding {encoding} for empty and scalar datasets"
+        )
+
+    if encoding == "csv":
+        return Response(
+            csv_encode(content_array),
+            headers={
+                "Content-Type": "text/csv",
+                "Content-Disposition": 'attachment; filename="data.csv"',
             },
         )
 

--- a/h5grove/encoders.py
+++ b/h5grove/encoders.py
@@ -111,7 +111,7 @@ def encode(content: Any, encoding: Optional[str] = "json") -> Response:
             headers={"Content-Type": "application/json"},
         )
 
-    content_array = np.array(content, copy=False)
+    content_array = np.asarray(content)
 
     if encoding == "bin":
         return Response(

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ dev =
 	types-contextvars
 	types-dataclasses
 	types-orjson
-	types-pkg-resources
+	types-setuptools
 
 # E501 (line too long) ignored for now
 # E203 and W503 incompatible with black formatting (https://black.readthedocs.io/en/stable/compatible_configs.html#flake8)

--- a/test/utils.py
+++ b/test/utils.py
@@ -64,7 +64,7 @@ def decode_array_response(
         assert content_type == "application/octet-stream"
         return np.frombuffer(response.content, dtype=dtype).reshape(shape)
 
-    return np.array(decode_response(response, format), copy=False)
+    return np.asarray(decode_response(response, format))
 
 
 def assert_error_response(response: Response, error_code: int):


### PR DESCRIPTION
Fix #94 

Also brings support for Numpy v2. See the discussion at https://github.com/silx-kit/h5grove/issues/94 for more info:

> As a rule of thumb, using `np.asarray` should be fine. Also, we have to remove the `copy=False` arg since it is visibly impossible to avoid copying when the argument is a scalar or a nested sequence (lists): https://numpy.org/devdocs/reference/generated/numpy.asarray.html#numpy.asarray
>
> By using `copy=None` (the default behaviour), copy is avoided when possible (ex: when the argument is a numpy array) but allowed when there is no other choice (as I said, scalars and nested sequences)