### PR TITLE
Use sync endpoints to avoid blocking

### DIFF
--- a/src/h5grove/fastapi_utils.py
+++ b/src/h5grove/fastapi_utils.py
@@ -80,13 +80,13 @@ async def add_base_path(file):
 
 
 @router.api_route("/")
-async def get_root():
+def get_root():
     """`/` endpoint handler to check server status"""
     return Response("ok")
 
 
 @router.get("/attr")
-async def get_attr(
+def get_attr(
     file: str = Depends(add_base_path),
     path: str = "/",
     attr_keys: list[str] | None = Query(default=None),
@@ -102,7 +102,7 @@ async def get_attr(
 
 
 @router.get("/data")
-async def get_data(
+def get_data(
     file: str = Depends(add_base_path),
     path: str = "/",
     dtype: str = "origin",
@@ -122,7 +122,7 @@ async def get_data(
 
 
 @router.get("/meta")
-async def get_meta(
+def get_meta(
     file: str = Depends(add_base_path),
     path: str = "/",
     resolve_links: str = "only_valid",
@@ -137,9 +137,7 @@ async def get_meta(
 
 
 @router.get("/stats")
-async def get_stats(
-    file: str = Depends(add_base_path), path: str = "/", selection=None
-):
+def get_stats(file: str = Depends(add_base_path), path: str = "/", selection=None):
     """`/stats` endpoint handler"""
     with get_content_from_file(file, path, create_error) as content:
         if not isinstance(content, DatasetContent):
@@ -151,7 +149,7 @@ async def get_stats(
 
 
 @router.get("/paths")
-async def get_paths(
+def get_paths(
     file: str = Depends(add_base_path),
     path: str = "/",
     resolve_links: str = "only_valid",


### PR DESCRIPTION
Because the logic does not involve async/await, using `async def` on those endpoints are effectively blocking the event loop, making the worker hang --- there is only one thread after all.
It is more reasonable to just use plain `def` here, in which case, the logic will be run in threads.

To illustrate, one can print some information (here time) at the entrance, calling the single server worker concurrently with 4 client workers.

### Use `def`

A single server worker can handle multiple requests concurrently.

```text
INFO:     ::1:41316 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41348 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41328 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41334 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434103.32655
1770434103.3281639
1770434103.3282027
1770434103.3282397
INFO:     ::1:41328 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41316 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41348 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41334 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434105.271086
1770434105.2729914
1770434105.2730117
1770434105.273075
INFO:     ::1:41328 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41316 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41334 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41348 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434107.197922
1770434107.214039
1770434107.214125
1770434107.2141488
INFO:     ::1:41328 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41334 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41316 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
INFO:     ::1:41348 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434109.2132182
1770434109.214771
1770434109.2148247
1770434109.2148628
```

### Use `async def`

It is effectively sequential.
When the data is large, encoding could be CPU intensive, making the worker unresponsive.

```text
1770434173.9083736
INFO:     ::1:44444 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434175.003437
INFO:     ::1:44444 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434175.2730403
INFO:     ::1:44440 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434175.548022
INFO:     ::1:44432 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434175.8183157
INFO:     ::1:44426 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434176.9236493
INFO:     ::1:44426 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434177.1997893
INFO:     ::1:44432 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434177.4714322
INFO:     ::1:44440 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434177.749755
INFO:     ::1:44444 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434178.9172912
INFO:     ::1:44444 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
1770434179.1978083
INFO:     ::1:44440 - "GET /data?path=%2Fsimulations%2Fhigh_res_flux&dtype=origin&format=json&flatten=false&file=complex_data.h5 HTTP/1.1" 200 OK
```