### PR TITLE
Pin setuptools to get around pytest-tornado error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-cov",
     "pytest-tornado",
     "ruff",
+    "setuptools<82",     # pytest-tornado still need pkg_resources (https://github.com/eugeniy/pytest-tornado/issues/67)
     "sphinx",
     "sphinx-argparse",
     "sphinx-autobuild",


### PR DESCRIPTION
Setuptools v82 removes `pkg_resources` while `pytest-tornado` still relies on it: https://github.com/eugeniy/pytest-tornado/issues/67

In this MR, I pin the `setuptools` version in the `dev` extra (since this is where the `pytest-tornado` dep is declared). Note that the project wasn't updated in 6 years so we may have to find an alternative :disappointed: 