### PR TITLE
Re-add HEAD method for "/" route with FastAPI

### DIFF
--- a/src/h5grove/fastapi_utils.py
+++ b/src/h5grove/fastapi_utils.py
@@ -79,7 +79,7 @@ async def add_base_path(file):
     return f"{settings.base_dir}/{file}" if settings.base_dir else file
 
 
-@router.api_route("/")
+@router.api_route("/", methods=["GET", "HEAD"])
 def get_root():
     """`/` endpoint handler to check server status"""
     return Response("ok")


### PR DESCRIPTION
Removed in #114: https://github.com/silx-kit/h5grove/pull/114/changes#diff-5a8810a6f207dbe134d11f9801a8c9bbbc4626c54683350e3d1efcb4a72c49a5L81

The `HEAD` method is used by tools like `wait-on` to check if the server is ready to receive requests.

The Flask implementation doesn't have the method yet, but I wasn't quite sure how to implement it because of the `Blueprint` syntax.