### PR TITLE
Fix missing user when running hatch publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,6 @@ jobs:
 
       - name: Release on PyPI 🎉
         env:
+          HATCH_INDEX_USER: '__token__'
           HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
         run: hatch publish -n


### PR DESCRIPTION
According to https://hatch.pypa.io/latest/how-to/publish/auth/, it should default to `__token__` but apparently it does not :shrug: 