### PR TITLE
Add custom H5 resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # VSCode
 .vscode
+
+# JetBrains IDEs
+.idea/

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -85,28 +85,27 @@ To do so, one shall subclass the `utils.H5FileResolver` class and implement the 
 The custom resolver can then be assigned via the `assign_resolver` function.
 
 ```python
+from contextlib import contextmanager
+from pathlib import Path
+
 from s3fs import S3FileSystem
+
 from h5grove import H5FileResolver, assign_resolver
 
-
 class S3Resolver(H5FileResolver):
-    def __init__(self, nominal_path: str):
-        super().__init__(nominal_path)
+    def __init__(self):
+        super().__init__()
         # using a local deployment for illustration
         # assuming anonymous access
-        self._s3 = S3FileSystem(anon=True, endpoint_url='http://localhost:8333')
-        self._fo = None
+        self._s3 = S3FileSystem(anon=True, endpoint_url="http://localhost:8333")
 
-    def __enter__(self):
-        self._fo = self._s3.open(self.nominal_path)
-        return self._fo
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._fo is not None:
-            self._fo.close()
+    @contextmanager
+    def resolve(self, nominal_path: str | Path):
+        with self._s3.open(nominal_path) as file:
+            yield file
 
 
-assign_resolver(S3Resolver)
+assign_resolver(S3Resolver())
 ```
 
 The `fsspec` library allows files stored in various sources to be accessed.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -108,3 +108,10 @@ class S3Resolver(H5FileResolver):
 
 assign_resolver(S3Resolver)
 ```
+
+The `fsspec` library allows files stored in various sources to be accessed.
+
+However, please note that if a file-like object is returned by the resolver, the external links may not work as
+intended.
+Since HDF5 library has no idea about different abstractions of file systems, it is almost certain that links have to be
+**manually** resolved.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -76,3 +76,35 @@ app.add_handlers(h5grove_handlers)
 .. automodule:: h5grove.tornado_utils
     :members:
 ```
+
+## Custom File Resolving
+
+By default, the HDF5 files are assumed to be on the local file system.
+It is possible to serve HDF5 files stored on a remote location.
+To do so, one shall subclass the `utils.H5FileResolver` class and implement the context manager protocol.
+The custom resolver can then be assigned via the `assign_resolver` function.
+
+```python
+from s3fs import S3FileSystem
+from h5grove import H5FileResolver, assign_resolver
+
+
+class S3Resolver(H5FileResolver):
+    def __init__(self, nominal_path: str):
+        super().__init__(nominal_path)
+        # using a local deployment for illustration
+        # assuming anonymous access
+        self._s3 = S3FileSystem(anon=True, endpoint_url='http://localhost:8333')
+        self._fo = None
+
+    def __enter__(self):
+        self._fo = self._s3.open(self.nominal_path)
+        return self._fo
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._fo is not None:
+            self._fo.close()
+
+
+assign_resolver(S3Resolver)
+```

--- a/src/h5grove/__init__.py
+++ b/src/h5grove/__init__.py
@@ -6,12 +6,12 @@ from .utils import H5FileResolver
 version = "4.0.0"
 
 
-def assign_resolver(custom_resolver: type[H5FileResolver]):
+def assign_resolver(resolver: H5FileResolver):
     """
     Assign a custom file resolver class.
     See the documentation of `H5FileResolver` for details.
     """
-    if not issubclass(custom_resolver, H5FileResolver):
+    if not isinstance(resolver, H5FileResolver):
         raise TypeError("The custom resolver must inherit from H5FileResolver.")
 
-    utils._resolver = custom_resolver
+    utils._resolver = resolver

--- a/src/h5grove/__init__.py
+++ b/src/h5grove/__init__.py
@@ -1,4 +1,17 @@
+from . import utils
 from .content import create_content
 from .encoders import encode
+from .utils import H5FileResolver
 
 version = "4.0.0"
+
+
+def assign_resolver(custom_resolver: type[H5FileResolver]):
+    """
+    Assign a custom file resolver class.
+    See the documentation of `H5FileResolver` for details.
+    """
+    if not issubclass(custom_resolver, H5FileResolver):
+        raise TypeError("The custom resolver must inherit from H5FileResolver.")
+
+    utils._resolver = custom_resolver

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -417,7 +417,7 @@ class LocalResolver(H5FileResolver):
             self._fo.close()
 
 
-_resolver = LocalResolver
+_resolver: type[H5FileResolver] = LocalResolver
 
 
 @contextmanager

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -397,24 +397,11 @@ class H5FileResolver(ABC):
 
 
 class LocalResolver(H5FileResolver):
-    """
-    A base class to define how the H5 files are resolved.
-    The constructor will be called with a single input argument `nominal_path`.
-
-    The derived class must implement the context manager protocol to return a file-like object opened in binary mode.
-    """
-
-    def __init__(self, nominal_path: str | Path):
-        super().__init__(nominal_path)
-        self._fo = None
-
     def __enter__(self):
-        self._fo = open(self.nominal_path, "rb")
-        return self._fo
+        return self.nominal_path
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._fo is not None:
-            self._fo.close()
+        pass
 
 
 _resolver: type[H5FileResolver] = LocalResolver

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from os.path import basename
@@ -378,36 +377,22 @@ def stringify_dtype(dtype: np.dtype) -> StrDtype:
     }
 
 
-class H5FileResolver(ABC):
+class H5FileResolver:
     """
     A base class to define how the H5 files are resolved.
-    The constructor will be called with a single input argument `nominal_path`.
 
-    The derived class must implement the context manager protocol to return
+    The derived class must implement the method `resolve` with context manager protocol to return
 
     1. a file-like object opened in binary mode, or
     2. a local path to the target file.
     """
 
-    def __init__(self, nominal_path: str | Path):
-        self.nominal_path = nominal_path
-
-    @abstractmethod
-    def __enter__(self): ...
-
-    @abstractmethod
-    def __exit__(self, exc_type, exc_val, exc_tb): ...
+    @contextmanager
+    def resolve(self, nominal_path: str | Path):
+        yield nominal_path
 
 
-class LocalResolver(H5FileResolver):
-    def __enter__(self):
-        return self.nominal_path
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-
-_resolver: type[H5FileResolver] = LocalResolver
+_resolver: H5FileResolver = H5FileResolver()
 
 
 @contextmanager
@@ -417,7 +402,7 @@ def open_file_with_error_fallback(
     h5py_options: dict[str, Any] = {},
 ) -> Iterator[h5py.File]:
     try:
-        with _resolver(filepath) as fo, h5py.File(fo, "r", **h5py_options) as f:
+        with _resolver.resolve(filepath) as fo, h5py.File(fo, "r", **h5py_options) as f:
             yield f
     except OSError as e:
         if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -383,7 +383,10 @@ class H5FileResolver(ABC):
     A base class to define how the H5 files are resolved.
     The constructor will be called with a single input argument `nominal_path`.
 
-    The derived class must implement the context manager protocol to return a file-like object opened in binary mode.
+    The derived class must implement the context manager protocol to return
+
+    1. a file-like object opened in binary mode, or
+    2. a local path to the target file.
     """
 
     def __init__(self, nominal_path: str | Path):

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -385,11 +385,20 @@ class H5FileResolver:
 
     1. a file-like object opened in binary mode, or
     2. a local path to the target file.
+
+    To pass further options to the `h5py.File` constructor, override the `extra_options` property.
     """
 
     @contextmanager
     def resolve(self, nominal_path: str | Path):
         yield nominal_path
+
+    @property
+    def extra_options(self) -> dict:
+        """
+        Return extra kwargs to be passed to `h5py.File`.
+        """
+        return {}
 
 
 _resolver: H5FileResolver = H5FileResolver()
@@ -402,7 +411,10 @@ def open_file_with_error_fallback(
     h5py_options: dict[str, Any] = {},
 ) -> Iterator[h5py.File]:
     try:
-        with _resolver.resolve(filepath) as fo, h5py.File(fo, "r", **h5py_options) as f:
+        with (
+            _resolver.resolve(filepath) as fo,
+            h5py.File(fo, "r", **(_resolver.extra_options | h5py_options)) as f,
+        ):
             yield f
     except OSError as e:
         if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):

--- a/src/h5grove/utils.py
+++ b/src/h5grove/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from os.path import basename
@@ -377,6 +378,48 @@ def stringify_dtype(dtype: np.dtype) -> StrDtype:
     }
 
 
+class H5FileResolver(ABC):
+    """
+    A base class to define how the H5 files are resolved.
+    The constructor will be called with a single input argument `nominal_path`.
+
+    The derived class must implement the context manager protocol to return a file-like object opened in binary mode.
+    """
+
+    def __init__(self, nominal_path: str | Path):
+        self.nominal_path = nominal_path
+
+    @abstractmethod
+    def __enter__(self): ...
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_val, exc_tb): ...
+
+
+class LocalResolver(H5FileResolver):
+    """
+    A base class to define how the H5 files are resolved.
+    The constructor will be called with a single input argument `nominal_path`.
+
+    The derived class must implement the context manager protocol to return a file-like object opened in binary mode.
+    """
+
+    def __init__(self, nominal_path: str | Path):
+        super().__init__(nominal_path)
+        self._fo = None
+
+    def __enter__(self):
+        self._fo = open(self.nominal_path, "rb")
+        return self._fo
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._fo is not None:
+            self._fo.close()
+
+
+_resolver = LocalResolver
+
+
 @contextmanager
 def open_file_with_error_fallback(
     filepath: str | Path,
@@ -384,7 +427,7 @@ def open_file_with_error_fallback(
     h5py_options: dict[str, Any] = {},
 ) -> Iterator[h5py.File]:
     try:
-        with h5py.File(filepath, "r", **h5py_options) as f:
+        with _resolver(filepath) as fo, h5py.File(fo, "r", **h5py_options) as f:
             yield f
     except OSError as e:
         if isinstance(e, FileNotFoundError) or "No such file or directory" in str(e):


### PR DESCRIPTION
After reconsidering, I do not think relying on the native S3 support in h5py/HDF5 is a practical approach for several reasons:

1. Enabling the `ros3` driver requires the underlying HDF5 library to be compiled with that feature enabled. Since h5py does not provide this by default, a custom build would almost always be necessary, which adds significant setup complexity.
2. Hard-coding credentials in advance reduces flexibility, especially when files may reside in different regions or deployments that require different authentication credentials.
3. It is incompatible with the current ecosystem (e.g. h5web) to send credentials in the request body, because doing so would require all downstream consumers to switch from GET-based access patterns to POST endpoints.

A more practical solution may be to introduce an additional abstraction layer responsible for converting file paths into file objects.

This approach:

1. minimizes the impact on existing code,
2. avoids introducing extra dependencies,
3. gives users full control over how file paths are resolved and interpreted, particularly when those paths are user-defined.
